### PR TITLE
add local api generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.7.12-slim-buster
+
+ADD ./requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt
+RUN apt-get update \
+	&& apt-get install zip -y

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,23 @@
+IMAGE := apinixtla
 ROOT := $(shell dirname $(realpath $(firstword ${MAKEFILE_LIST})))
+
+
+DOCKER_PARAMETERS := \
+        --user $(shell id -u) \
+        -v ${ROOT}:/app \
+        -w /app \
+        -e HOME=/tmp
+
+init_api_docker:
+	docker build -t ${IMAGE} .
+
+create_api_zip: .require-route
+	docker run -it --rm ${DOCKER_PARAMETERS} ${IMAGE} bash -c \
+		"rm -f /app/api.zip && \
+		cd /usr/local/lib/python3.7/site-packages && \
+		zip -r9 /app/api.zip . && \
+		cd /app/api && zip -g /app/api.zip -r . && \
+		cd /app/${route} && zip -g /app/api.zip -r ."
 
 init:
 	virtualenv venv && \
@@ -17,3 +36,8 @@ init_dockers:
 	for ROUTE in tsfeatures tsforecast tsbenchmarks tspreprocess; do \
 		make -C $$ROUTE init; \
 	done
+
+.require-route:
+ifndef route
+	$(error route is required)
+endif


### PR DESCRIPTION
I uploaded a Dockerfile to reproduce locally the `api.zip` file used by the lambda function. To run it locally, you need to use: 

- `make init_api_docker` to initialize the Docker image.
- `make create_api_zip route=tsfeatures` to create the `api.zip` file for the `tsfeatures` service. `tsfeatures` can be changed for the other services.