### PR TITLE
fix cast error and change unit of measure of distance, fix #15

### DIFF
--- a/tsfeatures/calendar/make_holidays.py
+++ b/tsfeatures/calendar/make_holidays.py
@@ -98,13 +98,11 @@ def distance_to_holiday(holiday_dates, dates):
 
     # Compute day distance to holiday
     distance = np.expand_dims(dates_np, axis=1) - np.expand_dims(holiday_dates_np, axis=0)
+    # convert to distance in days
+    distance = distance / np.timedelta64(1, 'D')
     distance = np.abs(distance)
     distance = np.min(distance, axis=1)
-    distance[distance>183] = 365 - distance[distance>183]
-    # Convert to minutes
-    distance = distance.astype(float)
-    distance /= 6e10
-    distance = distance.astype(int)
+    distance[distance > 183] = 365 - distance[distance > 183]
 
     return distance
 


### PR DESCRIPTION
issue explanation:
- distance is initially computed as a timedelta in nanoseconds
- the fix for end of date range `distance[distance > 183] = 365 - distance[distance > 183]` fails in the comparison `distance > 183` and is actually assuming that distance is in days

fix explanation:
- distance is explictly converted to be measure in days

related change:
- removed the conversion of distance to be measured in minutes, it will stay measured in days (I do not think this would affect the rest, but I might be mistaken)