### PR TITLE
[FIX] Add new order to docs hosted in readme.com

### DIFF
--- a/action_files/create_readme_docs.sh
+++ b/action_files/create_readme_docs.sh
@@ -15,6 +15,8 @@ for sub_dir in "${SUB_DIRS[@]}"; do
             python -m action_files.modify_markdown --file_path "$md_file" --slug_number "$counter"
 	    ((counter++))
 	done < <(find "$DIR" -type f -name "*.ipynb" -not -path "*/.ipynb_checkpoints/*" | sort)
+
+	python -m action_files.create_sdk_reference --slug_number "$counter" --save_dir ./nbs/_docs/docs/
     else
         echo "Directory $DIR does not exist."
     fi

--- a/action_files/create_readme_docs.sh
+++ b/action_files/create_readme_docs.sh
@@ -15,9 +15,9 @@ for sub_dir in "${SUB_DIRS[@]}"; do
             python -m action_files.modify_markdown --file_path "$md_file" --slug_number "$counter"
 	    ((counter++))
 	done < <(find "$DIR" -type f -name "*.ipynb" -not -path "*/.ipynb_checkpoints/*" | sort)
-
-	python -m action_files.create_sdk_reference --slug_number "$counter" --save_dir ./nbs/_docs/docs/
     else
         echo "Directory $DIR does not exist."
     fi
 done
+
+python -m action_files.create_sdk_reference --slug_number "$counter" --save_dir ./nbs/_docs/docs/

--- a/action_files/create_sdk_reference.py
+++ b/action_files/create_sdk_reference.py
@@ -1,0 +1,34 @@
+import os
+import re
+
+import fire
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def create_sdk_reference(
+        save_dir,
+        slug_number,
+        host_url=os.environ['README_HOST_URL'], 
+        category=os.environ['README_CATEGORY'],
+    ):
+    file_path = f'{save_dir}/{slug_number}_sdk_reference.md'
+    header = f"""---
+title: "SDK Reference"
+slug: "sdk_reference"
+order: {slug_number}
+type: "link"
+link_url: "https://nixtla.github.io/nixtla/timegpt.html"
+link_external: true
+category: {category}
+---
+
+    """
+    
+    with open(file_path, 'w', encoding='utf-8') as file:
+        file.write(header)
+
+if __name__=="__main__":
+    fire.Fire(create_sdk_reference)
+

--- a/action_files/modify_markdown.py
+++ b/action_files/modify_markdown.py
@@ -69,7 +69,6 @@ def modify_markdown(
     header = f"""---
 title: "{title}"
 slug: "{slug}"
-parentDocSlug: sdk-tutorials
 order: {slug_number}
 excerpt: "Learn how to do {title} with TimeGPT"
 category: {category}


### PR DESCRIPTION
This PR:
- Puts tutorials under the `Python SDK` section in readme.com.
- Adds the `SDK Reference` link automatically at the end of the list.  