### PR TITLE
[FIX] mv docs-scripts to action_files

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -29,6 +29,7 @@ jobs:
           pip install -Uq nbdev nbdev_plotly
           pip install -e ".[dev]"
           mkdir nbs/_extensions
+          mv action_files/docs-scripts docs-scripts
           cp -r docs-scripts/mintlify/ nbs/_extensions/
           python docs-scripts/update-quarto.py
           echo "procs = nbdev_plotly.plotly:PlotlyProc" >> settings.ini

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs-scripts"]
-	path = docs-scripts
+	path = action_files/docs-scripts
 	url = https://github.com/Nixtla/docs.git
 	branch = scripts


### PR DESCRIPTION
`.ferignore` has problems ignoring `docs-scripts` since it is a submodule. See #150. This PR moves `docs-scripts` to `action_files` to be ignored by fern. 
