### PR TITLE
[FIX] Filter API errors

### DIFF
--- a/nbs/timegpt.ipynb
+++ b/nbs/timegpt.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,7 +907,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1139,16 +1139,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/miniconda/envs/nixtlats/lib/python3.11/site-packages/statsforecast/core.py:25: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "### TimeGPT\n",
+       "\n",
+       ">      TimeGPT (token:str, environment:Optional[str]=None, max_retries:int=6,\n",
+       ">               retry_interval:int=10, max_wait_time:int=360)\n",
+       "\n",
+       "Constructs all the necessary attributes for the TimeGPT object.\n",
+       "\n",
+       "|    | **Type** | **Default** | **Details** |\n",
+       "| -- | -------- | ----------- | ----------- |\n",
+       "| token | str |  | The authorization token to interact with the TimeGPT API. |\n",
+       "| environment | Optional | None | Custom environment. Pass only if provided. |\n",
+       "| max_retries | int | 6 | The maximum number of attempts to make when calling the API before giving up. <br>It defines how many times the client will retry the API call if it fails. <br>Default value is 6, indicating the client will attempt the API call up to 6 times in total |\n",
+       "| retry_interval | int | 10 | The interval in seconds between consecutive retry attempts. <br>This is the waiting period before the client tries to call the API again after a failed attempt. <br>Default value is 10 seconds, meaning the client waits for 10 seconds between retries. |\n",
+       "| max_wait_time | int | 360 | The maximum total time in seconds that the client will spend on all retry attempts before giving up. <br>This sets an upper limit on the cumulative waiting time for all retry attempts. <br>If this time is exceeded, the client will stop retrying and raise an exception. <br>Default value is 360 seconds, meaning the client will cease retrying if the total time <br>spent on retries exceeds 360 seconds. <br>The client throws a ReadTimeout error after 60 seconds of inactivity. If you want to <br>catch these errors, use max_wait_time >> 60.  |"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "### TimeGPT\n",
+       "\n",
+       ">      TimeGPT (token:str, environment:Optional[str]=None, max_retries:int=6,\n",
+       ">               retry_interval:int=10, max_wait_time:int=360)\n",
+       "\n",
+       "Constructs all the necessary attributes for the TimeGPT object.\n",
+       "\n",
+       "|    | **Type** | **Default** | **Details** |\n",
+       "| -- | -------- | ----------- | ----------- |\n",
+       "| token | str |  | The authorization token to interact with the TimeGPT API. |\n",
+       "| environment | Optional | None | Custom environment. Pass only if provided. |\n",
+       "| max_retries | int | 6 | The maximum number of attempts to make when calling the API before giving up. <br>It defines how many times the client will retry the API call if it fails. <br>Default value is 6, indicating the client will attempt the API call up to 6 times in total |\n",
+       "| retry_interval | int | 10 | The interval in seconds between consecutive retry attempts. <br>This is the waiting period before the client tries to call the API again after a failed attempt. <br>Default value is 10 seconds, meaning the client waits for 10 seconds between retries. |\n",
+       "| max_wait_time | int | 360 | The maximum total time in seconds that the client will spend on all retry attempts before giving up. <br>This sets an upper limit on the cumulative waiting time for all retry attempts. <br>If this time is exceeded, the client will stop retrying and raise an exception. <br>Default value is 360 seconds, meaning the client will cease retrying if the total time <br>spent on retries exceeds 360 seconds. <br>The client throws a ReadTimeout error after 60 seconds of inactivity. If you want to <br>catch these errors, use max_wait_time >> 60.  |"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TimeGPT.__init__, title_level=3, name='TimeGPT')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1158,18 +1210,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "## TimeGPT.validate_token\n",
+       "\n",
+       ">      TimeGPT.validate_token (log:bool=True)\n",
+       "\n",
+       "Returns True if your token is valid."
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "## TimeGPT.validate_token\n",
+       "\n",
+       ">      TimeGPT.validate_token (log:bool=True)\n",
+       "\n",
+       "Returns True if your token is valid."
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TimeGPT.validate_token, title_level=2, name='TimeGPT.validate_token')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:__main__:Happy Forecasting! :), If you have questions or need support, please email ops@nixtla.io\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#| hide\n",
     "timegpt.validate_token()"
@@ -1177,9 +1273,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#| hide\n",
     "_timegpt = TimeGPT(os.environ['TIMEGPT_CUSTOM_URL_TOKEN'], os.environ['TIMEGPT_CUSTOM_URL'])\n",
@@ -1188,7 +1295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1201,7 +1308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1222,9 +1329,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1949-01-01</td>\n",
+       "      <td>112</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1949-02-01</td>\n",
+       "      <td>118</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1949-03-01</td>\n",
+       "      <td>132</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1949-04-01</td>\n",
+       "      <td>129</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1949-05-01</td>\n",
+       "      <td>121</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    timestamp  value\n",
+       "0  1949-01-01    112\n",
+       "1  1949-02-01    118\n",
+       "2  1949-03-01    132\n",
+       "3  1949-04-01    129\n",
+       "4  1949-05-01    121"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#| hide\n",
     "df = pd.read_csv('https://raw.githubusercontent.com/Nixtla/transfer-learning-time-series/main/datasets/air_passengers.csv')\n",
@@ -1233,7 +1409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1247,11 +1423,116 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
+    "#| hide\n",
     "from httpx import ReadTimeout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "def test_retry_behavior(side_effect, max_retries=5, retry_interval=5, max_wait_time=40, should_retry=True):\n",
+    "    mock_timegpt = TimeGPT(\n",
+    "        token=os.environ['TIMEGPT_TOKEN'], \n",
+    "        max_retries=max_retries, \n",
+    "        retry_interval=retry_interval, \n",
+    "        max_wait_time=max_wait_time,\n",
+    "    )\n",
+    "    init_time = time()\n",
+    "    with patch('nixtlats.client.Nixtla.timegpt_multi_series', side_effect=side_effect):\n",
+    "        test_fail(\n",
+    "            lambda: mock_timegpt.forecast(df=df, h=12, time_col='timestamp', target_col='value'),\n",
+    "        )\n",
+    "    total_mock_time = time() - init_time\n",
+    "    if should_retry:\n",
+    "        approx_epected_time = min((max_retries - 1) * retry_interval, max_wait_time)\n",
+    "        upper_expected_time = min(max_retries * retry_interval, max_wait_time)\n",
+    "        assert total_mock_time >= approx_epected_time, \"It is not retrying as expected\"\n",
+    "        # preprocessing time before the first api call should be less than 60 seconds\n",
+    "        assert total_mock_time - upper_expected_time - (max_retries - 1) * sleep_seconds <= sleep_seconds "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:__main__:Validating inputs...\n",
+      "INFO:__main__:Preprocessing dataframes...\n",
+      "INFO:__main__:Inferred freq: MS\n",
+      "INFO:__main__:Calling Forecast Endpoint...\n"
+     ]
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "It is not retrying as expected",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[29], line 17\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mraise_api_error_with_text\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m      4\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m ApiError(\n\u001b[1;32m      5\u001b[0m         status_code\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m503\u001b[39m, \n\u001b[1;32m      6\u001b[0m         body\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[38;5;124m        </body></html>\u001b[39m\n\u001b[1;32m     16\u001b[0m \u001b[38;5;124m        \u001b[39m\u001b[38;5;124m\"\"\"\u001b[39m)\n\u001b[0;32m---> 17\u001b[0m \u001b[43mtest_retry_behavior\u001b[49m\u001b[43m(\u001b[49m\u001b[43mraise_api_error_with_text\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[28], line 18\u001b[0m, in \u001b[0;36mtest_retry_behavior\u001b[0;34m(side_effect, max_retries, retry_interval, max_wait_time, should_retry)\u001b[0m\n\u001b[1;32m     16\u001b[0m approx_epected_time \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mmin\u001b[39m((max_retries \u001b[38;5;241m-\u001b[39m \u001b[38;5;241m1\u001b[39m) \u001b[38;5;241m*\u001b[39m retry_interval, max_wait_time)\n\u001b[1;32m     17\u001b[0m upper_expected_time \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mmin\u001b[39m(max_retries \u001b[38;5;241m*\u001b[39m retry_interval, max_wait_time)\n\u001b[0;32m---> 18\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m total_mock_time \u001b[38;5;241m>\u001b[39m\u001b[38;5;241m=\u001b[39m approx_epected_time, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mIt is not retrying as expected\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     19\u001b[0m \u001b[38;5;66;03m# preprocessing time before the first api call should be less than 60 seconds\u001b[39;00m\n\u001b[1;32m     20\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m total_mock_time \u001b[38;5;241m-\u001b[39m upper_expected_time \u001b[38;5;241m-\u001b[39m (max_retries \u001b[38;5;241m-\u001b[39m \u001b[38;5;241m1\u001b[39m) \u001b[38;5;241m*\u001b[39m sleep_seconds \u001b[38;5;241m<\u001b[39m\u001b[38;5;241m=\u001b[39m sleep_seconds\n",
+      "\u001b[0;31mAssertionError\u001b[0m: It is not retrying as expected"
+     ]
+    }
+   ],
+   "source": [
+    "#| hide\n",
+    "# we want the api to retry in these cases\n",
+    "def raise_api_error_with_text(*args, **kwargs):\n",
+    "    raise ApiError(\n",
+    "        status_code=503, \n",
+    "        body=\"\"\"\n",
+    "        <html><head>\n",
+    "        <meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">\n",
+    "        <title>503 Server Error</title>\n",
+    "        </head>\n",
+    "        <body text=#000000 bgcolor=#ffffff>\n",
+    "        <h1>Error: Server Error</h1>\n",
+    "        <h2>The service you requested is not available at this time.<p>Service error -27.</h2>\n",
+    "        <h2></h2>\n",
+    "        </body></html>\n",
+    "        \"\"\")\n",
+    "test_retry_behavior(raise_api_error_with_text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:__main__:Validating inputs...\n",
+      "INFO:__main__:Preprocessing dataframes...\n",
+      "INFO:__main__:Inferred freq: MS\n"
+     ]
+    }
+   ],
+   "source": [
+    "#| hide\n",
+    "# we want the api to not retry in these cases\n",
+    "# here A is assuming that the endpoint responds always\n",
+    "# with a json\n",
+    "def raise_api_error_with_json(*args, **kwargs):\n",
+    "    raise ApiError(\n",
+    "        status_code=503, \n",
+    "        body=dict(detail='Please use numbers'),\n",
+    "    )\n",
+    "test_retry_behavior(raise_api_error_with_json, should_retry=False)"
    ]
   },
   {
@@ -1278,18 +1559,15 @@
     "    (10, 1, 5),\n",
     "]\n",
     "side_effects = [raise_read_timeout_error, raise_http_error]\n",
+    "\n",
     "for (max_retries, retry_interval, max_wait_time), side_effect in product(combs, side_effects):\n",
-    "    mock_timegpt = TimeGPT(token=os.environ['TIMEGPT_TOKEN'], max_retries=max_retries, retry_interval=retry_interval, max_wait_time=max_wait_time)\n",
-    "    init_time = time()\n",
-    "    with patch('nixtlats.client.Nixtla.timegpt_multi_series', side_effect=side_effect):\n",
-    "        test_fail(\n",
-    "            lambda: mock_timegpt.forecast(df=df, h=12, time_col='timestamp', target_col='value'),\n",
-    "        )\n",
-    "    total_mock_time = time() - init_time\n",
-    "    approx_epected_time = min((max_retries - 1) * retry_interval, max_wait_time)\n",
-    "    upper_expected_time = min(max_retries * retry_interval, max_wait_time)\n",
-    "    assert total_mock_time >= approx_epected_time\n",
-    "    assert total_mock_time - upper_expected_time - (max_retries - 1) * sleep_seconds <= sleep_seconds # preprocessing time before the first api call shoulb be less than 60 seconds"
+    "    test_retry_behavior(\n",
+    "        max_retries=max_retries, \n",
+    "        retry_interval=retry_interval, \n",
+    "        max_wait_time=max_wait_time, \n",
+    "        side_effect=side_effect,\n",
+    "    )\n",
+    "    "
    ]
   },
   {
@@ -1681,9 +1959,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/nbs/timegpt.ipynb
+++ b/nbs/timegpt.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,8 +46,9 @@
     "from tenacity import (\n",
     "    retry, stop_after_attempt, \n",
     "    wait_fixed, stop_after_delay,\n",
+    "    RetryCallState, \n",
+    "    retry_if_exception, \n",
     "    retry_if_not_exception_type,\n",
-    "    RetryCallState,\n",
     ")\n",
     "\n",
     "from nixtlats.client import ApiError, Nixtla, SingleSeriesForecast\n",
@@ -60,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,12 +188,20 @@
     "        def after_retry(retry_state: RetryCallState):\n",
     "            \"\"\"Called after each retry attempt.\"\"\"\n",
     "            main_logger.info(f\"Attempt {retry_state.attempt_number} failed...\")\n",
+    "        # we want to retry when:\n",
+    "        # there is no ApiError \n",
+    "        # there is an ApiError with string body\n",
+    "        def is_api_error_with_text_body(exception):\n",
+    "            if isinstance(exception, ApiError):\n",
+    "                if isinstance(exception.body, str):\n",
+    "                    return True\n",
+    "            return False\n",
     "        return retry(\n",
     "            stop=(stop_after_attempt(self.max_retries) | stop_after_delay(self.max_wait_time)),\n",
     "            wait=wait_fixed(self.retry_interval),\n",
     "            reraise=True,\n",
     "            after=after_retry,\n",
-    "            retry=retry_if_not_exception_type(ApiError),\n",
+    "            retry=retry_if_exception(is_api_error_with_text_body) | retry_if_not_exception_type(ApiError),\n",
     "        )\n",
     "\n",
     "    def _call_api(self, method, kwargs):\n",
@@ -545,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,7 +916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1139,68 +1148,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/miniconda/envs/nixtlats/lib/python3.11/site-packages/statsforecast/core.py:25: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from tqdm.autonotebook import tqdm\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "### TimeGPT\n",
-       "\n",
-       ">      TimeGPT (token:str, environment:Optional[str]=None, max_retries:int=6,\n",
-       ">               retry_interval:int=10, max_wait_time:int=360)\n",
-       "\n",
-       "Constructs all the necessary attributes for the TimeGPT object.\n",
-       "\n",
-       "|    | **Type** | **Default** | **Details** |\n",
-       "| -- | -------- | ----------- | ----------- |\n",
-       "| token | str |  | The authorization token to interact with the TimeGPT API. |\n",
-       "| environment | Optional | None | Custom environment. Pass only if provided. |\n",
-       "| max_retries | int | 6 | The maximum number of attempts to make when calling the API before giving up. <br>It defines how many times the client will retry the API call if it fails. <br>Default value is 6, indicating the client will attempt the API call up to 6 times in total |\n",
-       "| retry_interval | int | 10 | The interval in seconds between consecutive retry attempts. <br>This is the waiting period before the client tries to call the API again after a failed attempt. <br>Default value is 10 seconds, meaning the client waits for 10 seconds between retries. |\n",
-       "| max_wait_time | int | 360 | The maximum total time in seconds that the client will spend on all retry attempts before giving up. <br>This sets an upper limit on the cumulative waiting time for all retry attempts. <br>If this time is exceeded, the client will stop retrying and raise an exception. <br>Default value is 360 seconds, meaning the client will cease retrying if the total time <br>spent on retries exceeds 360 seconds. <br>The client throws a ReadTimeout error after 60 seconds of inactivity. If you want to <br>catch these errors, use max_wait_time >> 60.  |"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "### TimeGPT\n",
-       "\n",
-       ">      TimeGPT (token:str, environment:Optional[str]=None, max_retries:int=6,\n",
-       ">               retry_interval:int=10, max_wait_time:int=360)\n",
-       "\n",
-       "Constructs all the necessary attributes for the TimeGPT object.\n",
-       "\n",
-       "|    | **Type** | **Default** | **Details** |\n",
-       "| -- | -------- | ----------- | ----------- |\n",
-       "| token | str |  | The authorization token to interact with the TimeGPT API. |\n",
-       "| environment | Optional | None | Custom environment. Pass only if provided. |\n",
-       "| max_retries | int | 6 | The maximum number of attempts to make when calling the API before giving up. <br>It defines how many times the client will retry the API call if it fails. <br>Default value is 6, indicating the client will attempt the API call up to 6 times in total |\n",
-       "| retry_interval | int | 10 | The interval in seconds between consecutive retry attempts. <br>This is the waiting period before the client tries to call the API again after a failed attempt. <br>Default value is 10 seconds, meaning the client waits for 10 seconds between retries. |\n",
-       "| max_wait_time | int | 360 | The maximum total time in seconds that the client will spend on all retry attempts before giving up. <br>This sets an upper limit on the cumulative waiting time for all retry attempts. <br>If this time is exceeded, the client will stop retrying and raise an exception. <br>Default value is 360 seconds, meaning the client will cease retrying if the total time <br>spent on retries exceeds 360 seconds. <br>The client throws a ReadTimeout error after 60 seconds of inactivity. If you want to <br>catch these errors, use max_wait_time >> 60.  |"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TimeGPT.__init__, title_level=3, name='TimeGPT')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1210,62 +1167,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "## TimeGPT.validate_token\n",
-       "\n",
-       ">      TimeGPT.validate_token (log:bool=True)\n",
-       "\n",
-       "Returns True if your token is valid."
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "## TimeGPT.validate_token\n",
-       "\n",
-       ">      TimeGPT.validate_token (log:bool=True)\n",
-       "\n",
-       "Returns True if your token is valid."
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TimeGPT.validate_token, title_level=2, name='TimeGPT.validate_token')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:__main__:Happy Forecasting! :), If you have questions or need support, please email ops@nixtla.io\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "timegpt.validate_token()"
@@ -1273,20 +1186,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "_timegpt = TimeGPT(os.environ['TIMEGPT_CUSTOM_URL_TOKEN'], os.environ['TIMEGPT_CUSTOM_URL'])\n",
@@ -1295,7 +1197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1308,7 +1210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1329,78 +1231,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>timestamp</th>\n",
-       "      <th>value</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1949-01-01</td>\n",
-       "      <td>112</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1949-02-01</td>\n",
-       "      <td>118</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1949-03-01</td>\n",
-       "      <td>132</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1949-04-01</td>\n",
-       "      <td>129</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>1949-05-01</td>\n",
-       "      <td>121</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    timestamp  value\n",
-       "0  1949-01-01    112\n",
-       "1  1949-02-01    118\n",
-       "2  1949-03-01    132\n",
-       "3  1949-04-01    129\n",
-       "4  1949-05-01    121"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "df = pd.read_csv('https://raw.githubusercontent.com/Nixtla/transfer-learning-time-series/main/datasets/air_passengers.csv')\n",
@@ -1409,7 +1242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1423,7 +1256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1433,12 +1266,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
-    "def test_retry_behavior(side_effect, max_retries=5, retry_interval=5, max_wait_time=40, should_retry=True):\n",
+    "def test_retry_behavior(side_effect, max_retries=5, retry_interval=5, max_wait_time=40, should_retry=True, sleep_seconds=5):\n",
     "    mock_timegpt = TimeGPT(\n",
     "        token=os.environ['TIMEGPT_TOKEN'], \n",
     "        max_retries=max_retries, \n",
@@ -1452,41 +1285,20 @@
     "        )\n",
     "    total_mock_time = time() - init_time\n",
     "    if should_retry:\n",
-    "        approx_epected_time = min((max_retries - 1) * retry_interval, max_wait_time)\n",
+    "        approx_expected_time = min((max_retries - 1) * retry_interval, max_wait_time)\n",
     "        upper_expected_time = min(max_retries * retry_interval, max_wait_time)\n",
-    "        assert total_mock_time >= approx_epected_time, \"It is not retrying as expected\"\n",
+    "        assert total_mock_time >= approx_expected_time, \"It is not retrying as expected\"\n",
     "        # preprocessing time before the first api call should be less than 60 seconds\n",
-    "        assert total_mock_time - upper_expected_time - (max_retries - 1) * sleep_seconds <= sleep_seconds "
+    "        assert total_mock_time - upper_expected_time - (max_retries - 1) * sleep_seconds <= sleep_seconds\n",
+    "    else:\n",
+    "        assert total_mock_time <= max_wait_time "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:__main__:Validating inputs...\n",
-      "INFO:__main__:Preprocessing dataframes...\n",
-      "INFO:__main__:Inferred freq: MS\n",
-      "INFO:__main__:Calling Forecast Endpoint...\n"
-     ]
-    },
-    {
-     "ename": "AssertionError",
-     "evalue": "It is not retrying as expected",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[29], line 17\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mraise_api_error_with_text\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m      4\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m ApiError(\n\u001b[1;32m      5\u001b[0m         status_code\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m503\u001b[39m, \n\u001b[1;32m      6\u001b[0m         body\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[38;5;124m        </body></html>\u001b[39m\n\u001b[1;32m     16\u001b[0m \u001b[38;5;124m        \u001b[39m\u001b[38;5;124m\"\"\"\u001b[39m)\n\u001b[0;32m---> 17\u001b[0m \u001b[43mtest_retry_behavior\u001b[49m\u001b[43m(\u001b[49m\u001b[43mraise_api_error_with_text\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[28], line 18\u001b[0m, in \u001b[0;36mtest_retry_behavior\u001b[0;34m(side_effect, max_retries, retry_interval, max_wait_time, should_retry)\u001b[0m\n\u001b[1;32m     16\u001b[0m approx_epected_time \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mmin\u001b[39m((max_retries \u001b[38;5;241m-\u001b[39m \u001b[38;5;241m1\u001b[39m) \u001b[38;5;241m*\u001b[39m retry_interval, max_wait_time)\n\u001b[1;32m     17\u001b[0m upper_expected_time \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mmin\u001b[39m(max_retries \u001b[38;5;241m*\u001b[39m retry_interval, max_wait_time)\n\u001b[0;32m---> 18\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m total_mock_time \u001b[38;5;241m>\u001b[39m\u001b[38;5;241m=\u001b[39m approx_epected_time, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mIt is not retrying as expected\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     19\u001b[0m \u001b[38;5;66;03m# preprocessing time before the first api call should be less than 60 seconds\u001b[39;00m\n\u001b[1;32m     20\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m total_mock_time \u001b[38;5;241m-\u001b[39m upper_expected_time \u001b[38;5;241m-\u001b[39m (max_retries \u001b[38;5;241m-\u001b[39m \u001b[38;5;241m1\u001b[39m) \u001b[38;5;241m*\u001b[39m sleep_seconds \u001b[38;5;241m<\u001b[39m\u001b[38;5;241m=\u001b[39m sleep_seconds\n",
-      "\u001b[0;31mAssertionError\u001b[0m: It is not retrying as expected"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "# we want the api to retry in these cases\n",
@@ -1504,24 +1316,14 @@
     "        <h2></h2>\n",
     "        </body></html>\n",
     "        \"\"\")\n",
-    "test_retry_behavior(raise_api_error_with_text)"
+    "test_retry_behavior(raise_api_error_with_text, retry_interval=1)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:__main__:Validating inputs...\n",
-      "INFO:__main__:Preprocessing dataframes...\n",
-      "INFO:__main__:Inferred freq: MS\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "# we want the api to not retry in these cases\n",
@@ -1543,7 +1345,6 @@
    "source": [
     "#| hide\n",
     "# test resilience of api calls\n",
-    "sleep_seconds = 5\n",
     "\n",
     "def raise_read_timeout_error(*args, **kwargs):\n",
     "    print(f'raising ReadTimeout error after {sleep_seconds} seconds')\n",
@@ -1555,7 +1356,7 @@
     "    raise HTTPError(response=dict(status_code=503))\n",
     "    \n",
     "combs = [\n",
-    "    (4, 5, 30),\n",
+    "    (2, 5, 30),\n",
     "    (10, 1, 5),\n",
     "]\n",
     "side_effects = [raise_read_timeout_error, raise_http_error]\n",
@@ -1959,21 +1760,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Before this PR, `tenacity` was invoked when errors different than `ApiError` from `httpx` were raised. However, when the endpoint is momentarily unavailable, the client often raises an `ApiError` with a text body.  See:

https://github.com/Nixtla/nixtla/blob/1e2e632de98ee079286f1bcf77c8a07a99f8c65a/nixtlats/client.py#L229

This behavior can be used as a proxy for the unavailability of the endpoint. If the endpoint is available but has a server error, the endpoint should return a JSON-decodable response, and a text response otherwise.

This approach was implemented in this PR and tested with a couple of tests ensuring retrying with a response of [this kind](https://github.com/Nixtla/nixtla/actions/runs/6791773732/job/18463888068#step:5:173) and providing no retrying when the server responds in a JSON-decodable manner. 