### PR TITLE
[FIX] Mintlify prefixes, readme file dirs

### DIFF
--- a/action_files/readme_com/create_readme_docs.sh
+++ b/action_files/readme_com/create_readme_docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BASE_DIR="nbs/docs/"
-SUB_DIRS=("getting-started" "capabilities/forecast" "capabilities/anomaly-detection" "deployment" "tutorials" "use-cases")
+SUB_DIRS=("getting-started" "capabilities" "deployment" "tutorials" "use-cases")
 
 counter=0
 for sub_dir in "${SUB_DIRS[@]}"; do

--- a/action_files/readme_com/create_readme_docs.sh
+++ b/action_files/readme_com/create_readme_docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BASE_DIR="nbs/docs/"
-SUB_DIRS=("getting-started" "capabilities" "deployment" "tutorials" "use-cases")
+SUB_DIRS=("getting-started" "capabilities/forecast" "capabilities/anomaly-detection" "deployment" "tutorials" "use-cases")
 
 counter=0
 for sub_dir in "${SUB_DIRS[@]}"; do

--- a/nbs/docs/capabilities/000_capabilities.ipynb
+++ b/nbs/docs/capabilities/000_capabilities.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6de758ee-a0d2-4b3f-acff-eed419dd17c5",
+   "metadata": {},
+   "source": [
+    "# Capabilities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d267032-535b-4b7b-b7d3-d2db8f673af6",
+   "metadata": {},
+   "source": [
+    "This section offers an overview of capabilities of TimeGPT"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbs/mint.json
+++ b/nbs/mint.json
@@ -27,10 +27,10 @@
     {
       "group": "Getting Started",
       "pages": [
-        "docs/getting-started/1_introduction.html",
-        "docs/getting-started/2_quickstart.html",
-        "docs/getting-started/3_setting_up_your_api_key.html",
-        "docs/getting-started/7_faq.html"      
+        "docs/getting-started/introduction.html",
+        "docs/getting-started/quickstart.html",
+        "docs/getting-started/setting_up_your_api_key.html",
+        "docs/getting-started/faq.html"      
       ]
     },
     {
@@ -39,26 +39,26 @@
         {
           "group": "Forecast",
           "pages": [
-            "docs/capabilities/forecast/01_quickstart.html",
-            "docs/capabilities/forecast/02_exogenous_variables.html",
-            "docs/capabilities/forecast/03_holidays_special_dates.html",
-            "docs/capabilities/forecast/04_categorical_variables.html",
-            "docs/capabilities/forecast/05_longhorizon.html",
-            "docs/capabilities/forecast/06_multiple_series.html",
-            "docs/capabilities/forecast/07_finetuning.html",
-            "docs/capabilities/forecast/08_custom_loss_functions.html",
-            "docs/capabilities/forecast/09_cross_validation.html",
-            "docs/capabilities/forecast/10_prediction_intervals.html",
-            "docs/capabilities/forecast/11_irregular_timestamps.html"
+            "docs/capabilities/forecast/quickstart.html",
+            "docs/capabilities/forecast/exogenous_variables.html",
+            "docs/capabilities/forecast/holidays_special_dates.html",
+            "docs/capabilities/forecast/categorical_variables.html",
+            "docs/capabilities/forecast/longhorizon.html",
+            "docs/capabilities/forecast/multiple_series.html",
+            "docs/capabilities/forecast/finetuning.html",
+            "docs/capabilities/forecast/custom_loss_functions.html",
+            "docs/capabilities/forecast/cross_validation.html",
+            "docs/capabilities/forecast/prediction_intervals.html",
+            "docs/capabilities/forecast/irregular_timestamps.html"
           ]
         },
         {
           "group": "Anomaly Detection",
           "pages": [
-            "docs/capabilities/anomaly-detection/01_quickstart.html",
-            "docs/capabilities/anomaly-detection/02_anomaly_exogenous.html",
-            "docs/capabilities/anomaly-detection/03_anomaly_detection_date_features.html",
-            "docs/capabilities/anomaly-detection/04_confidence_levels.html"
+            "docs/capabilities/anomaly-detection/quickstart.html",
+            "docs/capabilities/anomaly-detection/anomaly_exogenous.html",
+            "docs/capabilities/anomaly-detection/anomaly_detection_date_features.html",
+            "docs/capabilities/anomaly-detection/confidence_levels.html"
           ]
         }
       ]
@@ -66,7 +66,7 @@
     {
       "group": "Deployment",
       "pages": [
-        "docs/deployment/2_azure_ai.html"
+        "docs/deployment/azure_ai.html"
       ]
     },
     {
@@ -75,54 +75,54 @@
         {
           "group":"Exogenous variables",
           "pages":[
-            "docs/tutorials/01_exogenous_variables.html", 
-            "docs/tutorials/02_holidays.html",
-            "docs/tutorials/03_categorical_variables.html"
+            "docs/tutorials/exogenous_variables.html", 
+            "docs/tutorials/holidays.html",
+            "docs/tutorials/categorical_variables.html"
           ]
         },
         {
           "group":"Training",
           "pages":[
-            "docs/tutorials/04_longhorizon.html",
-            "docs/tutorials/05_multiple_series.html"
+            "docs/tutorials/longhorizon.html",
+            "docs/tutorials/multiple_series.html"
           ]
         },
         {
           "group":"Fine-tuning",
           "pages":[
-            "docs/tutorials/06_finetuning.html",
-            "docs/tutorials/07_loss_function_finetuning.html"
+            "docs/tutorials/finetuning.html",
+            "docs/tutorials/loss_function_finetuning.html"
           ]
         },
         {
           "group":"Validation",
           "pages":[
-            "docs/tutorials/08_cross_validation.html",
-            "docs/tutorials/09_historical_forecast.html"
+            "docs/tutorials/cross_validation.html",
+            "docs/tutorials/historical_forecast.html"
           ]
         },
         {
           "group":"Uncertainty quantification",
           "pages":[
-            "docs/tutorials/10_uncertainty_quantification_with_quantile_forecasts.html",
-            "docs/tutorials/11_uncertainty_quantification_with_prediction_intervals.html"
+            "docs/tutorials/uncertainty_quantification_with_quantile_forecasts.html",
+            "docs/tutorials/uncertainty_quantification_with_prediction_intervals.html"
           ]
         },
         {
           "group":"Special Topics",
           "pages":[
-            "docs/tutorials/12_irregular_timestamps.html",
-            "docs/tutorials/13_bounded_forecasts.html",
-            "docs/tutorials/14_hierarchical_forecasting.html"
+            "docs/tutorials/irregular_timestamps.html",
+            "docs/tutorials/bounded_forecasts.html",
+            "docs/tutorials/hierarchical_forecasting.html"
           ]
         },
         {
           "group":"Computing at scale",
           "pages":[
-            "docs/tutorials/15_computing_at_scale.html",
-            "docs/tutorials/16_computing_at_scale_spark_distributed.html",
-            "docs/tutorials/17_computing_at_scale_dask_distributed.html",
-            "docs/tutorials/18_computing_at_scale_ray_distributed.html"            
+            "docs/tutorials/computing_at_scale.html",
+            "docs/tutorials/computing_at_scale_spark_distributed.html",
+            "docs/tutorials/computing_at_scale_dask_distributed.html",
+            "docs/tutorials/computing_at_scale_ray_distributed.html"            
           ]
         }        
       ]
@@ -130,8 +130,8 @@
     {
       "group": "Use cases",
       "pages": [
-        "docs/use-cases/1_forecasting_web_traffic.html",
-        "docs/use-cases/2_bitcoin_price_prediction.html"
+        "docs/use-cases/forecasting_web_traffic.html",
+        "docs/use-cases/bitcoin_price_prediction.html"
     ]
     },
     {


### PR DESCRIPTION
- Mintlify prefixes removed in mint.json as apparently mintlify removes the prefix from a filename (?)
- Readme.com file dirs - apparently readme.com gives an error if there is no placeholder notebook in the capabilities folder. This was not the case in the test branch, though. Adding it renders the docs properly again.