### PR TITLE
fix: add pyreadr as dev dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ dev = [
     "plotly",
     "pre-commit",
     "python-dotenv",
+    "pyreadr",
     "statsforecast",
     "neuralforecast",
     "hierarchicalforecast",


### PR DESCRIPTION
some [ci/cd tests](https://github.com/Nixtla/nixtla/actions/runs/8954169466/job/24593482500?pr=335) were failing due to this missing dep in `nbs/docs/tutorials/13_bounded_forecasts.ipynb`