### PR TITLE
fix: update distributed to computing at scale

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,8 +88,8 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests 
-        run: nbdev_test --skip_file_glob "*computing_at_scale*"
+        run: nbdev_test --skip_file_glob "*computing_at_scale*" --skip_file_glob "*distributed*"
 
       - name: Run tests with distributed (ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: nbdev_test --file_glob "*computing_at_scale*"
+        run: nbdev_test --file_glob "*computing_at_scale*" --file_glob "*distributed*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,8 +88,8 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests 
-        run: nbdev_test --skip_file_glob "*distributed*"
+        run: nbdev_test --skip_file_glob "*computing_at_scale*"
 
       - name: Run tests with distributed (ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: nbdev_test --file_glob "*distributed*"
+        run: nbdev_test --file_glob "*computing_at_scale*"


### PR DESCRIPTION
recent docs changes, made the current file glob unusable for skipping distributed tutorials on some operating systems. this pr fixes the problem.