### PR TITLE
fix: Chronos inference in foundation ts arena

### DIFF
--- a/experiments/foundation-time-series-arena/eval-chronos.py
+++ b/experiments/foundation-time-series-arena/eval-chronos.py
@@ -1,0 +1,34 @@
+import fire
+import transformers
+from xiuhmolpilli.arena import FoundationalTimeSeriesArena
+from xiuhmolpilli.models.foundational import Chronos
+
+
+if __name__ == "__main__":
+    transformers.set_seed(42)  # for reproducibility
+
+    frequencies = ["Hourly", "Daily", "Weekly", "Monthly"]
+    files = [
+        f"./nixtla-foundational-time-series/data/{freq}.parquet" for freq in frequencies
+    ]
+    arena = FoundationalTimeSeriesArena(
+        models=[
+            Chronos(
+                repo_id="amazon/chronos-t5-large", batch_size=16, alias="Chronos-Large"
+            ),
+            Chronos(
+                repo_id="amazon/chronos-t5-base", batch_size=40, alias="Chronos-Base"
+            ),
+            Chronos(
+                repo_id="amazon/chronos-t5-small", batch_size=64, alias="Chronos-Small"
+            ),
+            Chronos(
+                repo_id="amazon/chronos-t5-mini", batch_size=128, alias="Chronos-Mini"
+            ),
+            Chronos(
+                repo_id="amazon/chronos-t5-tiny", batch_size=256, alias="Chronos-Tiny"
+            ),
+        ],
+        parquet_data_paths=files,
+    )
+    fire.Fire(arena.compete)


### PR DESCRIPTION
Thank you for evaluating Chronos again. It's great to see it performing accurately on this benchmark as well.

We found some issues with the way inference is being done for Chronos. Particularly, [excess `NaN` padding was being applied](https://github.com/Nixtla/nixtla/blob/ff7c1d66fd4986613b531eb0f2d9da8f022e67f1/experiments/foundation-time-series-arena/xiuhmolpilli/models/foundational/chronos.py#L34-L45) to short time series which is not required and would slow down the model significantly. This PR fixes this issue. The following table shows a comparison of Chronos (Large)'s performance before (taken from the original table in this repo) and after these fixes, and also reports performance of other variants of Chronos. These experiments were performed on a `g5.4xlarge` instance, as in the [original study](https://github.com/Nixtla/nixtla/tree/ff7c1d66fd4986613b531eb0f2d9da8f022e67f1/experiments/foundation-time-series-arena).

<div>
<table border="1" class="dataframe">
  <thead>
    <tr>
      <th></th>
      <th colspan="4" halign="left">Accuracy</th>
      <th colspan="4" halign="left">Inference Time</th>
    </tr>
    <tr>
      <th></th>
      <th>Monthly</th>
      <th>Weekly</th>
      <th>Daily</th>
      <th>Hourly</th>
      <th>Monthly</th>
      <th>Weekly</th>
      <th>Daily</th>
      <th>Hourly</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>Chronos-Large (Before)</th>
      <td>0.960</td>
      <td>0.709</td>
      <td>0.652</td>
      <td>0.735</td>
      <td>38.581</td>
      <td>5.081</td>
      <td>7.908</td>
      <td>11.662</td>
    </tr>
    <tr>
      <th>Chronos-Large</th>
      <td>0.950</td>
      <td>0.704</td>
      <td>0.652</td>
      <td>0.654</td>
      <td>5.402</td>
      <td>5.054</td>
      <td>7.882</td>
      <td>11.500</td>
    </tr>
    <tr>
      <th>Chronos-Base</th>
      <td>0.966</td>
      <td>0.709</td>
      <td>0.663</td>
      <td>0.646</td>
      <td>1.966</td>
      <td>1.712</td>
      <td>2.940</td>
      <td>4.714</td>
    </tr>
    <tr>
      <th>Chronos-Small</th>
      <td>0.982</td>
      <td>0.724</td>
      <td>0.669</td>
      <td>0.671</td>
      <td>0.689</td>
      <td>0.550</td>
      <td>0.986</td>
      <td>1.818</td>
    </tr>
    <tr>
      <th>Chronos-Mini</th>
      <td>0.968</td>
      <td>0.736</td>
      <td>0.682</td>
      <td>0.729</td>
      <td>0.476</td>
      <td>0.356</td>
      <td>0.688</td>
      <td>1.371</td>
    </tr>
    <tr>
      <th>Chronos-Tiny</th>
      <td>0.976</td>
      <td>0.765</td>
      <td>0.686</td>
      <td>0.799</td>
      <td>0.316</td>
      <td>0.212</td>
      <td>0.427</td>
      <td>0.965</td>
    </tr>
  </tbody>
</table>
</div>

We observe:
- improvements in the MASE for Monthly (~1%) and Hourly (~11%) datasets. 
- a significant improvement (~38mins to ~5mins) in the inference time for the Monthly subset which has many very short time series.
- smaller Chronos models provide a quality-speed trade-off with the Base model performing almost as well as Large while being much faster, and even the mini model performing better than most baselines in the [original study](https://github.com/Nixtla/nixtla/tree/ff7c1d66fd4986613b531eb0f2d9da8f022e67f1/experiments/foundation-time-series-arena).

Here's how the average MASE ranking plots look like before and after the fix:
![image](https://github.com/Nixtla/nixtla/assets/4028948/af4e5442-0bb1-47f3-82e8-20d795083841)

Chronos-Large achieves the best overall rank (center). Chronos-Base obtains the same overall ranking as TimesFM and TimeGPT (right).

For the fidelity of the study, we recommend that the authors update their results and discussions accordingly, ideally after an independent verification with the latest code change (see usage below). Thank you again for your effort!

## Usage

- Download data and setup environment as described [here](https://github.com/Nixtla/nixtla/tree/main/experiments/foundation-time-series-arena).
- Run `python eval-chronos.py` to re-evaluate (only) Chronos.