### PR TITLE
fix: removed data input restriction during cross validation finetune

### DIFF
--- a/nbs/nixtla_client.ipynb
+++ b/nbs/nixtla_client.ipynb
@@ -20,16 +20,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide \n",
     "%load_ext autoreload\n",
@@ -1729,61 +1720,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/yibeihu/opt/anaconda3/envs/nixtla/lib/python3.10/site-packages/statsforecast/core.py:27: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from tqdm.autonotebook import tqdm\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "## NixtlaClient\n",
-       "\n",
-       ">      NixtlaClient (api_key:Optional[str]=None, base_url:Optional[str]=None,\n",
-       ">                    max_retries:int=6, retry_interval:int=10,\n",
-       ">                    max_wait_time:int=360)\n",
-       "\n",
-       "*Constructs all the necessary attributes for the NixtlaClient object.*\n",
-       "\n",
-       "|    | **Type** | **Default** | **Details** |\n",
-       "| -- | -------- | ----------- | ----------- |\n",
-       "| api_key | Optional | None | The authorization api_key interacts with the Nixtla API.<br>If not provided, it will be inferred by the NIXTLA_API_KEY environment variable. |\n",
-       "| base_url | Optional | None | Custom base_url. Pass only if provided. |\n",
-       "| max_retries | int | 6 | The maximum number of attempts to make when calling the API before giving up. <br>It defines how many times the client will retry the API call if it fails. <br>Default value is 6, indicating the client will attempt the API call up to 6 times in total |\n",
-       "| retry_interval | int | 10 | The interval in seconds between consecutive retry attempts. <br>This is the waiting period before the client tries to call the API again after a failed attempt. <br>Default value is 10 seconds, meaning the client waits for 10 seconds between retries. |\n",
-       "| max_wait_time | int | 360 | The maximum total time in seconds that the client will spend on all retry attempts before giving up. <br>This sets an upper limit on the cumulative waiting time for all retry attempts. <br>If this time is exceeded, the client will stop retrying and raise an exception. <br>Default value is 360 seconds, meaning the client will cease retrying if the total time <br>spent on retries exceeds 360 seconds. <br>The client throws a ReadTimeout error after 60 seconds of inactivity. If you want to <br>catch these errors, use max_wait_time >> 60.  |"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "## NixtlaClient\n",
-       "\n",
-       ">      NixtlaClient (api_key:Optional[str]=None, base_url:Optional[str]=None,\n",
-       ">                    max_retries:int=6, retry_interval:int=10,\n",
-       ">                    max_wait_time:int=360)\n",
-       "\n",
-       "*Constructs all the necessary attributes for the NixtlaClient object.*\n",
-       "\n",
-       "|    | **Type** | **Default** | **Details** |\n",
-       "| -- | -------- | ----------- | ----------- |\n",
-       "| api_key | Optional | None | The authorization api_key interacts with the Nixtla API.<br>If not provided, it will be inferred by the NIXTLA_API_KEY environment variable. |\n",
-       "| base_url | Optional | None | Custom base_url. Pass only if provided. |\n",
-       "| max_retries | int | 6 | The maximum number of attempts to make when calling the API before giving up. <br>It defines how many times the client will retry the API call if it fails. <br>Default value is 6, indicating the client will attempt the API call up to 6 times in total |\n",
-       "| retry_interval | int | 10 | The interval in seconds between consecutive retry attempts. <br>This is the waiting period before the client tries to call the API again after a failed attempt. <br>Default value is 10 seconds, meaning the client waits for 10 seconds between retries. |\n",
-       "| max_wait_time | int | 360 | The maximum total time in seconds that the client will spend on all retry attempts before giving up. <br>This sets an upper limit on the cumulative waiting time for all retry attempts. <br>If this time is exceeded, the client will stop retrying and raise an exception. <br>Default value is 360 seconds, meaning the client will cease retrying if the total time <br>spent on retries exceeds 360 seconds. <br>The client throws a ReadTimeout error after 60 seconds of inactivity. If you want to <br>catch these errors, use max_wait_time >> 60.  |"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(NixtlaClient.__init__, title_level=2, name='NixtlaClient')"
    ]
@@ -1792,39 +1729,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "#### TimeGPT\n",
-       "\n",
-       ">      TimeGPT (*args, **kwargs)\n",
-       "\n",
-       "*Class `TimeGPT` is deprecated; use `NixtlaClient` instead.\n",
-       "\n",
-       "This class is deprecated and may be removed in future releases.\n",
-       "Please use `NixtlaClient` instead.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "#### TimeGPT\n",
-       "\n",
-       ">      TimeGPT (*args, **kwargs)\n",
-       "\n",
-       "*Class `TimeGPT` is deprecated; use `NixtlaClient` instead.\n",
-       "\n",
-       "This class is deprecated and may be removed in future releases.\n",
-       "Please use `NixtlaClient` instead.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(TimeGPT, title_level=4)"
    ]
@@ -1899,33 +1804,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "## NixtlaClient.validate_api_key\n",
-       "\n",
-       ">      NixtlaClient.validate_api_key (log:bool=True)\n",
-       "\n",
-       "*Returns True if your api_key is valid.*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "## NixtlaClient.validate_api_key\n",
-       "\n",
-       ">      NixtlaClient.validate_api_key (log:bool=True)\n",
-       "\n",
-       "*Returns True if your api_key is valid.*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(NixtlaClient.validate_api_key, title_level=2, name='NixtlaClient.validate_api_key')"
    ]
@@ -1934,33 +1813,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "---\n",
-       "\n",
-       "#### NixtlaClient.validate_token\n",
-       "\n",
-       ">      NixtlaClient.validate_token ()\n",
-       "\n",
-       "*this is deprecated in favor of validate_api_key*"
-      ],
-      "text/plain": [
-       "---\n",
-       "\n",
-       "#### NixtlaClient.validate_token\n",
-       "\n",
-       ">      NixtlaClient.validate_token ()\n",
-       "\n",
-       "*this is deprecated in favor of validate_api_key*"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_doc(NixtlaClient.validate_token, title_level=4, name='NixtlaClient.validate_token')"
    ]
@@ -1969,25 +1822,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:__main__:Happy Forecasting! :), If you have questions or need support, please email ops@nixtla.io\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "nixtla_client.validate_api_key()"
@@ -1997,18 +1832,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:__main__:Happy Forecasting! :), If you have questions or need support, please email ops@nixtla.io\n",
-      "/var/folders/mt/bm2h50kj2872xhymzl24djch0000gn/T/ipykernel_92429/2077030078.py:6: FutureWarning: Method `validate_token` is deprecated; use `validate_api_key` instead.\n",
-      "  warnings.warn(\n",
-      "INFO:__main__:Happy Forecasting! :), If you have questions or need support, please email ops@nixtla.io\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "# test validate_token deprecation\n",
@@ -2028,20 +1852,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "KeyError",
-     "evalue": "'NIXTLA_API_KEY_CUSTOM'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[34], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m#| hide\u001b[39;00m\n\u001b[1;32m      2\u001b[0m _nixtla_client \u001b[38;5;241m=\u001b[39m NixtlaClient(\n\u001b[0;32m----> 3\u001b[0m     api_key\u001b[38;5;241m=\u001b[39m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43menviron\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mNIXTLA_API_KEY_CUSTOM\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m, \n\u001b[1;32m      4\u001b[0m     base_url\u001b[38;5;241m=\u001b[39mos\u001b[38;5;241m.\u001b[39menviron[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mNIXTLA_BASE_URL_CUSTOM\u001b[39m\u001b[38;5;124m'\u001b[39m],\n\u001b[1;32m      5\u001b[0m )\n\u001b[1;32m      6\u001b[0m _nixtla_client\u001b[38;5;241m.\u001b[39mvalidate_api_key()\n",
-      "File \u001b[0;32m~/opt/anaconda3/envs/nixtla/lib/python3.10/os.py:680\u001b[0m, in \u001b[0;36m_Environ.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    677\u001b[0m     value \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_data[\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mencodekey(key)]\n\u001b[1;32m    678\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m:\n\u001b[1;32m    679\u001b[0m     \u001b[38;5;66;03m# raise KeyError with the original key value\u001b[39;00m\n\u001b[0;32m--> 680\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m    681\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdecodevalue(value)\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'NIXTLA_API_KEY_CUSTOM'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "_nixtla_client = NixtlaClient(\n",

--- a/nbs/nixtla_client.ipynb
+++ b/nbs/nixtla_client.ipynb
@@ -2628,6 +2628,23 @@
    "outputs": [],
    "source": [
     "#| hide\n",
+    "# test finetune cv\n",
+    "finetune_cv = nixtla_client.cross_validation(\n",
+    "            df=df_,\n",
+    "            h=12,\n",
+    "            n_windows=1,\n",
+    "            finetune_steps=1\n",
+    "        )\n",
+    "test_eq(finetune_cv is not None, True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
     "for hyp in hyps:\n",
     "    fcst_test = nixtla_client.forecast(df_train, h=12, **hyp)\n",
     "    fcst_test = df_test[['unique_id', 'ds', 'y']].merge(fcst_test)\n",

--- a/nbs/nixtla_client.ipynb
+++ b/nbs/nixtla_client.ipynb
@@ -20,7 +20,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "#| hide \n",
     "%load_ext autoreload\n",
@@ -743,10 +752,9 @@
     "        self.set_model_params()\n",
     "        if x_cols:\n",
     "            X_df = df[['unique_id', 'ds', *x_cols]]\n",
-    "            restrict_input = False\n",
     "        else:\n",
     "            X_df = None\n",
-    "            restrict_input = True\n",
+    "        restrict_input = self.finetune_steps == 0 and X_df is None\n",
     "        if restrict_input:\n",
     "            if step_size is None:\n",
     "                step_size = self.h\n",
@@ -1721,7 +1729,61 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/yibeihu/opt/anaconda3/envs/nixtla/lib/python3.10/site-packages/statsforecast/core.py:27: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "## NixtlaClient\n",
+       "\n",
+       ">      NixtlaClient (api_key:Optional[str]=None, base_url:Optional[str]=None,\n",
+       ">                    max_retries:int=6, retry_interval:int=10,\n",
+       ">                    max_wait_time:int=360)\n",
+       "\n",
+       "*Constructs all the necessary attributes for the NixtlaClient object.*\n",
+       "\n",
+       "|    | **Type** | **Default** | **Details** |\n",
+       "| -- | -------- | ----------- | ----------- |\n",
+       "| api_key | Optional | None | The authorization api_key interacts with the Nixtla API.<br>If not provided, it will be inferred by the NIXTLA_API_KEY environment variable. |\n",
+       "| base_url | Optional | None | Custom base_url. Pass only if provided. |\n",
+       "| max_retries | int | 6 | The maximum number of attempts to make when calling the API before giving up. <br>It defines how many times the client will retry the API call if it fails. <br>Default value is 6, indicating the client will attempt the API call up to 6 times in total |\n",
+       "| retry_interval | int | 10 | The interval in seconds between consecutive retry attempts. <br>This is the waiting period before the client tries to call the API again after a failed attempt. <br>Default value is 10 seconds, meaning the client waits for 10 seconds between retries. |\n",
+       "| max_wait_time | int | 360 | The maximum total time in seconds that the client will spend on all retry attempts before giving up. <br>This sets an upper limit on the cumulative waiting time for all retry attempts. <br>If this time is exceeded, the client will stop retrying and raise an exception. <br>Default value is 360 seconds, meaning the client will cease retrying if the total time <br>spent on retries exceeds 360 seconds. <br>The client throws a ReadTimeout error after 60 seconds of inactivity. If you want to <br>catch these errors, use max_wait_time >> 60.  |"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "## NixtlaClient\n",
+       "\n",
+       ">      NixtlaClient (api_key:Optional[str]=None, base_url:Optional[str]=None,\n",
+       ">                    max_retries:int=6, retry_interval:int=10,\n",
+       ">                    max_wait_time:int=360)\n",
+       "\n",
+       "*Constructs all the necessary attributes for the NixtlaClient object.*\n",
+       "\n",
+       "|    | **Type** | **Default** | **Details** |\n",
+       "| -- | -------- | ----------- | ----------- |\n",
+       "| api_key | Optional | None | The authorization api_key interacts with the Nixtla API.<br>If not provided, it will be inferred by the NIXTLA_API_KEY environment variable. |\n",
+       "| base_url | Optional | None | Custom base_url. Pass only if provided. |\n",
+       "| max_retries | int | 6 | The maximum number of attempts to make when calling the API before giving up. <br>It defines how many times the client will retry the API call if it fails. <br>Default value is 6, indicating the client will attempt the API call up to 6 times in total |\n",
+       "| retry_interval | int | 10 | The interval in seconds between consecutive retry attempts. <br>This is the waiting period before the client tries to call the API again after a failed attempt. <br>Default value is 10 seconds, meaning the client waits for 10 seconds between retries. |\n",
+       "| max_wait_time | int | 360 | The maximum total time in seconds that the client will spend on all retry attempts before giving up. <br>This sets an upper limit on the cumulative waiting time for all retry attempts. <br>If this time is exceeded, the client will stop retrying and raise an exception. <br>Default value is 360 seconds, meaning the client will cease retrying if the total time <br>spent on retries exceeds 360 seconds. <br>The client throws a ReadTimeout error after 60 seconds of inactivity. If you want to <br>catch these errors, use max_wait_time >> 60.  |"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(NixtlaClient.__init__, title_level=2, name='NixtlaClient')"
    ]
@@ -1730,7 +1792,39 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "#### TimeGPT\n",
+       "\n",
+       ">      TimeGPT (*args, **kwargs)\n",
+       "\n",
+       "*Class `TimeGPT` is deprecated; use `NixtlaClient` instead.\n",
+       "\n",
+       "This class is deprecated and may be removed in future releases.\n",
+       "Please use `NixtlaClient` instead.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "#### TimeGPT\n",
+       "\n",
+       ">      TimeGPT (*args, **kwargs)\n",
+       "\n",
+       "*Class `TimeGPT` is deprecated; use `NixtlaClient` instead.\n",
+       "\n",
+       "This class is deprecated and may be removed in future releases.\n",
+       "Please use `NixtlaClient` instead.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(TimeGPT, title_level=4)"
    ]
@@ -1805,7 +1899,33 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "## NixtlaClient.validate_api_key\n",
+       "\n",
+       ">      NixtlaClient.validate_api_key (log:bool=True)\n",
+       "\n",
+       "*Returns True if your api_key is valid.*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "## NixtlaClient.validate_api_key\n",
+       "\n",
+       ">      NixtlaClient.validate_api_key (log:bool=True)\n",
+       "\n",
+       "*Returns True if your api_key is valid.*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(NixtlaClient.validate_api_key, title_level=2, name='NixtlaClient.validate_api_key')"
    ]
@@ -1814,7 +1934,33 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "#### NixtlaClient.validate_token\n",
+       "\n",
+       ">      NixtlaClient.validate_token ()\n",
+       "\n",
+       "*this is deprecated in favor of validate_api_key*"
+      ],
+      "text/plain": [
+       "---\n",
+       "\n",
+       "#### NixtlaClient.validate_token\n",
+       "\n",
+       ">      NixtlaClient.validate_token ()\n",
+       "\n",
+       "*this is deprecated in favor of validate_api_key*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(NixtlaClient.validate_token, title_level=4, name='NixtlaClient.validate_token')"
    ]
@@ -1823,7 +1969,25 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:__main__:Happy Forecasting! :), If you have questions or need support, please email ops@nixtla.io\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#| hide\n",
     "nixtla_client.validate_api_key()"
@@ -1833,7 +1997,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:__main__:Happy Forecasting! :), If you have questions or need support, please email ops@nixtla.io\n",
+      "/var/folders/mt/bm2h50kj2872xhymzl24djch0000gn/T/ipykernel_92429/2077030078.py:6: FutureWarning: Method `validate_token` is deprecated; use `validate_api_key` instead.\n",
+      "  warnings.warn(\n",
+      "INFO:__main__:Happy Forecasting! :), If you have questions or need support, please email ops@nixtla.io\n"
+     ]
+    }
+   ],
    "source": [
     "#| hide\n",
     "# test validate_token deprecation\n",
@@ -1853,7 +2028,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'NIXTLA_API_KEY_CUSTOM'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[34], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m#| hide\u001b[39;00m\n\u001b[1;32m      2\u001b[0m _nixtla_client \u001b[38;5;241m=\u001b[39m NixtlaClient(\n\u001b[0;32m----> 3\u001b[0m     api_key\u001b[38;5;241m=\u001b[39m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43menviron\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mNIXTLA_API_KEY_CUSTOM\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m, \n\u001b[1;32m      4\u001b[0m     base_url\u001b[38;5;241m=\u001b[39mos\u001b[38;5;241m.\u001b[39menviron[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mNIXTLA_BASE_URL_CUSTOM\u001b[39m\u001b[38;5;124m'\u001b[39m],\n\u001b[1;32m      5\u001b[0m )\n\u001b[1;32m      6\u001b[0m _nixtla_client\u001b[38;5;241m.\u001b[39mvalidate_api_key()\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/nixtla/lib/python3.10/os.py:680\u001b[0m, in \u001b[0;36m_Environ.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    677\u001b[0m     value \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_data[\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mencodekey(key)]\n\u001b[1;32m    678\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m:\n\u001b[1;32m    679\u001b[0m     \u001b[38;5;66;03m# raise KeyError with the original key value\u001b[39;00m\n\u001b[0;32m--> 680\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m    681\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdecodevalue(value)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'NIXTLA_API_KEY_CUSTOM'"
+     ]
+    }
+   ],
    "source": [
     "#| hide\n",
     "_nixtla_client = NixtlaClient(\n",

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -687,10 +687,9 @@ class _NixtlaClientModel:
         self.set_model_params()
         if x_cols:
             X_df = df[["unique_id", "ds", *x_cols]]
-            restrict_input = False
         else:
             X_df = None
-            restrict_input = True
+        restrict_input = self.finetune_steps == 0 and X_df is None
         if restrict_input:
             if step_size is None:
                 step_size = self.h


### PR DESCRIPTION
Addresses issue https://github.com/Nixtla/nixtla/issues/424.

The current implementation of cross_validation restricts historical data even when finetune_steps is not zero. This restriction causes an UnprocessableEntityError when fine-tuning is used in cross-validation. 

For instance, the following code using web traffic sample data generates this error:
```
cv_df = nixtla_client.cross_validation(
    df,
    h=7,
    step_size = 7,
    n_windows=1,
    time_col='date',
    target_col='users',
    id_col = 'unique_id',
    freq='D',
    finetune_steps = 10
)

UnprocessableEntityError: status_code: 422, body: detail=None requestID='C2T6854CVQ' details='request had an error' support='If you have questions or need support, please email ops@nixtla.io' data={'detail': 'Minimum number of samples by id required for finetuning is 29, got 28.'}
```
To resolve this issue, I added a condition to deactivate the _restrict_input_samples function when finetune_steps is not zero. This ensures that sufficient historical data is available during fine-tuning in cross-validation.