### PR TITLE
ci: install dev requirements in deploy-readme action

### DIFF
--- a/.github/workflows/deploy-readme.yaml
+++ b/.github/workflows/deploy-readme.yaml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install pip requirements
-        run: pip install ./
+        run: pip install ".[dev]"
 
       - name: Install Quarto
         run: nbdev_install_quarto

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ with open("README.md", "r", encoding="utf8") as fh:
 dev = [
     "black",
     "datasetsforecast",
+    "fire",
     "hierarchicalforecast",
     "jupyterlab",
     "nbdev",


### PR DESCRIPTION
The [action is failing](https://github.com/Nixtla/nixtla/actions/runs/10255664075/job/28373067923#step:6:13) because nbdev isn't being installed