### PR TITLE
[FIX] Create docs on release not on push to main

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,7 +1,7 @@
 name: "build-docs"
 on:
-  push:
-    branches: ["main"]
+  release:
+    types: [released]
   pull_request:
     branches: ["main"]
   workflow_dispatch:
@@ -45,7 +45,9 @@ jobs:
           cp nbs/mint.json _docs/mint.json
           cp docs-scripts/imgs/* _docs/
       - name: Deploy to Mintlify Docs
-        if: github.event_name == 'push'
+        if: | 
+          github.event_name == 'release' || 
+          github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -54,7 +56,9 @@ jobs:
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
       - name: Trigger mintlify workflow
-        if: github.event_name == 'push'
+        if: | 
+          github.event_name == 'release' ||
+          github.event_name == 'workflow_dispatch'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.DOCS_WORKFLOW_TOKEN }}
@@ -68,7 +72,9 @@ jobs:
       - name: Configure redirects for gh-pages
         run: python docs-scripts/configure-redirects.py nixtla
       - name: Deploy to Github Pages
-        if: github.event_name == 'push'
+        if: | 
+          github.event_name == 'release' ||
+          github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-readme.yaml
+++ b/.github/workflows/deploy-readme.yaml
@@ -1,8 +1,8 @@
 name: Deploy to readme dot com
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
This PR modifies the github workflows to create docs on release OR on explicit workflow_dispatch. 

The benefit is that we can push doc PRs to main whilst the features these docs describe aren't necessarily included in the release yet. Basically, this syncs our docs with our releases. 

On-demand doc fixing (when a PR is merged to main) can always still be realized by manually triggering the necessary workflows.