### PR TITLE
fix(docs): use different title in polars quickstart

### DIFF
--- a/nbs/docs/getting-started/21_polars_quickstart.ipynb
+++ b/nbs/docs/getting-started/21_polars_quickstart.ipynb
@@ -51,7 +51,7 @@
    "id": "6ecd9d32-9178-4768-bffa-d70c93c98311",
    "metadata": {},
    "source": [
-    "# TimeGPT Quickstart\n",
+    "# TimeGPT Quickstart (Polars)\n",
     "\n",
     "> TimeGPT is a production ready, generative pretrained transformer for time series. It's capable of accurately predicting various domains such as retail, electricity, finance, and IoT with just a few lines of code 🚀."
    ]


### PR DESCRIPTION
for the docs to render correctly we need to add a unique title to each notebook. later, the title becomes the slug used by readme to deploy the docs, so we need to keep them unique. this pr fixes the problem with the polars quickstart