### PR TITLE
enh: update validate_api_key to use GET request

### DIFF
--- a/nbs/src/nixtla_client.ipynb
+++ b/nbs/src/nixtla_client.ipynb
@@ -1000,20 +1000,28 @@
     "        return df, X_df, drop_id, freq\n",
     "\n",
     "    def validate_api_key(self, log: bool = True) -> bool:\n",
-    "        \"\"\"Returns True if your api_key is valid.\"\"\"\n",
-    "        try:\n",
-    "            with httpx.Client(**self._client_kwargs) as client:\n",
-    "                validation = self._make_request_with_retries(\n",
-    "                    client, 'validate_token', {}\n",
-    "                )\n",
-    "        except:\n",
-    "            validation = {}\n",
-    "        if 'support' in validation and log:\n",
-    "            logger.info(f'Happy Forecasting! :), {validation[\"support\"]}')\n",
-    "        return (\n",
-    "            validation.get('message', '') == 'success'\n",
-    "            or 'Forecasting! :)' in validation.get('detail', '')\n",
-    "        )\n",
+    "        \"\"\"Check API key status.\n",
+    "        \n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        log : bool (default=True)\n",
+    "            Show the endpoint's response.\n",
+    "            \n",
+    "        Returns\n",
+    "        -------\n",
+    "        bool\n",
+    "            Whether API key is valid.\"\"\"\n",
+    "        if self._is_azure:\n",
+    "            raise NotImplementedError(\n",
+    "                'validate_api_key is not implemented for Azure deployments, '\n",
+    "                'you can try using the forecasting methods directly.'\n",
+    "            )\n",
+    "        with httpx.Client(**self._client_kwargs) as client:\n",
+    "            resp = client.get(\"/validate_api_key\")\n",
+    "            body = resp.json()\n",
+    "        if log:\n",
+    "            logger.info(body[\"detail\"])\n",
+    "        return resp.status_code == 200\n",
     "\n",
     "    def usage(self) -> dict[str, dict[str, int]]:\n",
     "        \"\"\"Query consumed requests and limits\n",
@@ -2465,7 +2473,7 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "nixtla_client.validate_api_key()"
+    "assert nixtla_client.validate_api_key()"
    ]
   },
   {
@@ -2479,7 +2487,8 @@
     "custom_client = NixtlaClient(\n",
     "    base_url=os.environ['NIXTLA_BASE_URL_CUSTOM'],\n",
     "    api_key=os.environ['NIXTLA_API_KEY_CUSTOM'],\n",
-    ")"
+    ")\n",
+    "assert custom_client.validate_api_key()"
    ]
   },
   {

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -928,19 +928,28 @@ class NixtlaClient:
         return df, X_df, drop_id, freq
 
     def validate_api_key(self, log: bool = True) -> bool:
-        """Returns True if your api_key is valid."""
-        try:
-            with httpx.Client(**self._client_kwargs) as client:
-                validation = self._make_request_with_retries(
-                    client, "validate_token", {}
-                )
-        except:
-            validation = {}
-        if "support" in validation and log:
-            logger.info(f'Happy Forecasting! :), {validation["support"]}')
-        return validation.get(
-            "message", ""
-        ) == "success" or "Forecasting! :)" in validation.get("detail", "")
+        """Check API key status.
+
+        Parameters
+        ----------
+        log : bool (default=True)
+            Show the endpoint's response.
+
+        Returns
+        -------
+        bool
+            Whether API key is valid."""
+        if self._is_azure:
+            raise NotImplementedError(
+                "validate_api_key is not implemented for Azure deployments, "
+                "you can try using the forecasting methods directly."
+            )
+        with httpx.Client(**self._client_kwargs) as client:
+            resp = client.get("/validate_api_key")
+            body = resp.json()
+        if log:
+            logger.info(body["detail"])
+        return resp.status_code == 200
 
     def usage(self) -> dict[str, dict[str, int]]:
         """Query consumed requests and limits


### PR DESCRIPTION
Updates the `validate_api_key` method to perform a `GET /validate_api_key` instead of `POST /validate_token`, since we don't send any data.

Also updates the definition of the method to include a docstring and log the endpoint response.