### PR TITLE
DOCS: Fix links for online anomaly detection

### DIFF
--- a/nbs/docs/capabilities/online-anomaly-detection/00_online_anomaly_detection.ipynb
+++ b/nbs/docs/capabilities/online-anomaly-detection/00_online_anomaly_detection.ipynb
@@ -17,9 +17,9 @@
     "\n",
     "This section covers:\n",
     "\n",
-    "* [Online anomaly detection](https://docs.nixtla.io/docs/capabilities-online-anomaly-detection-quickstart)\n",
+    "* [Online anomaly detection](https://docs.nixtla.io/docs/capabilities-online-anomaly-detection-introduction_to_online_real_time_anomaly_detection)\n",
     "\n",
-    "* [How to adjust the detection process](https://docs.nixtla.io/docs/capabilities-online-anomaly-detection-adjusting_detection_process.ipynb)\n",
+    "* [How to adjust the detection process](https://docs.nixtla.io/docs/capabilities-online-anomaly-detection-adjusting_the_anomaly_detection_process)\n",
     "\n",
     "* [Univariate vs. multiseries anomaly detection](https://docs.nixtla.io/docs/capabilities-online-anomaly-detection-univariate_vs_multivariate_anomaly_detection)\n"
    ]


### PR DESCRIPTION
There were broken links in the docs for online anomaly detection. This fixes the links.