### PR TITLE
CHORE: add nodejs to codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,6 +51,10 @@
     "waitFor": "postCreateCommand",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2.12.2": {},
-        "ghcr.io/va-h/devcontainers-features/uv:1": {}
+        "ghcr.io/va-h/devcontainers-features/uv:1": {},
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "lts",
+            "nodeGlobalInstallDirectory": "/usr/local/share/npm-global"
+        }
     }
 }


### PR DESCRIPTION
NodeJS is required to preview the documentation locally using the command `mint dev`. With NodeJS installed, we can run:
- `npm i -g mint`
- `mint dev` to preview the documentation