### PR TITLE
FIX: Add closing steps tag

### DIFF
--- a/timegpt-docs/introduction/about_timegpt.mdx
+++ b/timegpt-docs/introduction/about_timegpt.mdx
@@ -32,6 +32,7 @@ TimeGPT is a production-ready generative pretrained transformer model specifical
   <Step title="3. Forecast or Detect Anomalies">
     Perform zero-shot inference out-of-the-box to forecast future values or detect anomalies. Fine-tune the model if you need more targeted performance.
   </Step>
+</Steps>
 
 <Check>
 For detailed instructions and advanced configurations, visit our


### PR DESCRIPTION
Adds the closing `</Steps>` tag to render the about page correctly.