### PR TITLE
hotfix: _partition_series method handles None future exogenous variables

### DIFF
--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -329,9 +329,12 @@ def _partition_series(
         else:
             part_series["X"] = [x[part_idxs] for x in series["X"]]
             if h > 0:
-                part_series["X_future"] = [
-                    x[i * h : (i + series_per_part) * h] for x in series["X_future"]
-                ]
+                if series["X_future"] is None: 
+                    part_series["X_future"] = None
+                else:
+                    part_series["X_future"] = [
+                        x[i * h : (i + series_per_part) * h] for x in series["X_future"]
+                    ]
         if "categorical_exog" in series:
             part_series["categorical_exog"] = series["categorical_exog"]
         parts.append({"series": part_series, **payload})

--- a/nixtla_tests/nixtla_client/test_nixtla_client.py
+++ b/nixtla_tests/nixtla_client/test_nixtla_client.py
@@ -314,6 +314,43 @@ def test_num_partitions_same_results_parametrized(
 
 
 @pytest.mark.parametrize(
+    "method_name,method_kwargs",
+    [
+        ("forecast", {"h": 7}),
+        ("cross_validation", {"h": 7, "n_windows": 2}),
+        (
+            "detect_anomalies_online",
+            {"h": 20, "detection_size": 5, "threshold_method": "univariate"},
+        ),
+    ],
+)
+def test_num_partitions_hist_exog_no_x_df(
+    nixtla_test_client, df_freq_generator, method_name, method_kwargs
+):
+    # Regression for GH #806: when hist_exog_list is set but X_df is None,
+    # _partition_series previously raised because series["X"] was populated
+    # but series["X_future"] was None (only reached when h > 0, i.e.
+    # forecast / cross_validation). detect_anomalies lacks hist_exog_list so
+    # it is covered by test_num_partitions_same_results_parametrized instead.
+    df = df_freq_generator(n_series=4, min_length=200, max_length=220, freq="D")
+    df["hist_exog"] = 1.0
+
+    method_mapper = {
+        "forecast": nixtla_test_client.forecast,
+        "cross_validation": nixtla_test_client.cross_validation,
+        "detect_anomalies_online": nixtla_test_client.detect_anomalies_online,
+    }
+
+    check_num_partitions_same_results(
+        method=method_mapper[method_name],
+        num_partitions=2,
+        df=df,
+        hist_exog_list=["hist_exog"],
+        **method_kwargs,
+    )
+
+
+@pytest.mark.parametrize(
     "freq,h",
     [
         ("D", 7),


### PR DESCRIPTION
## Description 

When `num_partitions` is used and there are historical exogenous variables available, the `_partition_series` method doesn't account for the case where there are no future exogenous variables. It unconditionally tries `for x in series["X_future"]`, which is `None`. This generates `TypeError: 'NoneType' object is not iterable.`. 

This PR fixes this issue. 