### PR TITLE
[Fix] Publish to package should not simply based on the main branch

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,7 +3,6 @@ name: Upload Python Packages
 on:
   push:
     tags: ['v*']
-    branches: ['main']   # tag must be reachable from main branch
 
 jobs:
   deploy:
@@ -12,6 +11,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Ensure tag commit is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor $GITHUB_SHA origin/main
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0


### PR DESCRIPTION
# Rationale
 * In the previous PR: https://github.com/Nixtla/nixtla/pull/807/changes#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377R6 we should not add the condition of `branches: ['main']` because that shall simply trigger the release of package whenever we merge a new commit to the main branch