### PR TITLE
[DOC] Update of documentation on the deprecation notice for /v2/historic_forecast

### DIFF
--- a/timegpt-docs/openapi.json
+++ b/timegpt-docs/openapi.json
@@ -2059,9 +2059,10 @@
     },
     "/v2/historic_forecast": {
       "post": {
-        "summary": "Foundational Time Series Model Multi Series Historic",
-        "description": "Based on the provided data, this endpoint predicts the in-sample period (historical period) values of multiple time series at once. It takes a JSON as an input containing information like the series frequency and historical data. (See below for a full description of the parameters.) The response contains the predicted values for the historical period. Usually useful for anomaly detection. Get your token for private beta at https://nixtla.io/free-trial?utm_source=nixtla.io&utm_campaign=/docs/api-reference.",
+        "summary": "Foundational Time Series Model Multi Series Historic (Deprecated)",
+        "description": "**Deprecated:** This endpoint is deprecated and will be removed in a future release. Please use [`/v2/cross_validation`](#tag/default/POST/v2/cross_validation) instead, which offers equivalent in-sample evaluation capabilities through rolling-window cross validation.\n\nBased on the provided data, this endpoint predicts the in-sample period (historical period) values of multiple time series at once. It takes a JSON as an input containing information like the series frequency and historical data. (See below for a full description of the parameters.) The response contains the predicted values for the historical period. Usually useful for anomaly detection. Get your token for private beta at https://nixtla.io/free-trial?utm_source=nixtla.io&utm_campaign=/docs/api-reference.",
         "operationId": "v2_historic_forecast_v2_historic_forecast_post",
+        "deprecated": true,
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
Attached is the screenshot I generated locally in codespace as preview
<img width="1496" height="829" alt="image" src="https://github.com/user-attachments/assets/dec8c1f6-732b-4a2e-a454-890ca8a3c207" />
