### PR TITLE
docs: sync OpenAPI for nixtla-engine v0.2.7

### DIFF
--- a/timegpt-docs/openapi.json
+++ b/timegpt-docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Nixtla Forecast API",
     "description": "API for TimeGPT forecast. Just send your data as json and get results. We do the heavy lifting.",
-    "version": "0.2.4"
+    "version": "0.2.7"
   },
   "paths": {
     "/v2/forecast": {


### PR DESCRIPTION
## Sync OpenAPI doc for nixtla-engine v0.2.7

Propagates `openapi.json` from nixtla-engine into
`timegpt-docs/openapi.json` so the generated documentation matches the
released API surface.

Release notes: https://github.com/Nixtla/nixtla-engine/releases/tag/v0.2.7

🤖 Generated by the `release-deploy` workflow.
