### PR TITLE
Fix grain texture 404 across preview and production (nixtla.io/docs/) roots

### DIFF
--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -1022,8 +1022,8 @@ body::after {
   inset: 0;
   z-index: 9999;
   pointer-events: none;
-  /* png tile, matches nixtla.io */
-  background-image: url("/tex_noise.png");
+  /* both roots: / and /docs */
+  background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
   background-repeat: repeat;
   background-size: var(--grain-size);
   filter: grayscale(1) contrast(1.5);


### PR DESCRIPTION
The film-grain overlay (body::after on the docs) referenced its texture with a single absolute path, url("/tex_noise.png"). This broke in production because the preview and production sites serve at different base paths:

- Preview (…mintlify.site/) serves at the domain root → /tex_noise.png resolves.
- Production (www.nixtla.io/docs/…, a Vercel app rewriting /docs/* to Mintlify) serves the docs under /docs/. There, /tex_noise.png hits the main website root (404); the real asset lives at /docs/tex_noise.png.