### PR TITLE
docs(styles): tokenize style.css into a design system + styling adjustments

### DIFF
--- a/timegpt-docs/accordion-scroll-lock.js
+++ b/timegpt-docs/accordion-scroll-lock.js
@@ -10,7 +10,10 @@
  */
 (function () {
   var SEL = "details.accordion > summary, details.expandable > summary";
-  var PIN_MS = 400; // covers the 0.4s open animation + smooth-scroll frames
+  // Covers the open animation + smooth-scroll frames. Coupled by value to the
+  // CSS token --duration-slow (0.4s) that drives the accordion animation — if
+  // that token changes, keep this in sync (no shared source across CSS/JS).
+  var PIN_MS = 400;
 
   document.addEventListener(
     "click",

--- a/timegpt-docs/accordion-scroll-lock.js
+++ b/timegpt-docs/accordion-scroll-lock.js
@@ -10,7 +10,7 @@
  */
 (function () {
   var SEL = "details.accordion > summary, details.expandable > summary";
-  var PIN_MS = 700; // covers the 0.4s open animation + smooth-scroll frames
+  var PIN_MS = 400; // covers the 0.4s open animation + smooth-scroll frames
 
   document.addEventListener(
     "click",
@@ -29,6 +29,6 @@
       }
       requestAnimationFrame(pin);
     },
-    true
+    true,
   );
 })();

--- a/timegpt-docs/accordion-scroll-lock.js
+++ b/timegpt-docs/accordion-scroll-lock.js
@@ -1,0 +1,34 @@
+/*
+ * Accordion open/close: keep the scroll position steady.
+ *
+ * Mintlify deep-links accordions — opening one sets location.hash to the
+ * accordion id, which makes the browser scroll to that anchor (scroll-margin-top
+ * + html { scroll-behavior: smooth }). That reads as the page "jumping". CSS
+ * can't cancel fragment navigation, so we pin the scroll position for a short
+ * window after a summary click, defeating the anchor scroll while KEEPING the
+ * hash (the shareable link still works). Runs in dev and prod.
+ */
+(function () {
+  var SEL = "details.accordion > summary, details.expandable > summary";
+  var PIN_MS = 700; // covers the 0.4s open animation + smooth-scroll frames
+
+  document.addEventListener(
+    "click",
+    function (e) {
+      var summary = e.target.closest && e.target.closest(SEL);
+      if (!summary) return;
+
+      var y = window.scrollY;
+      var start = -1;
+
+      function pin(now) {
+        if (start < 0) start = now;
+        // Only correct if something tried to move us — avoids fighting the user.
+        if (window.scrollY !== y) window.scrollTo(0, y);
+        if (now - start < PIN_MS) requestAnimationFrame(pin);
+      }
+      requestAnimationFrame(pin);
+    },
+    true
+  );
+})();

--- a/timegpt-docs/code-group-tab-labels.js
+++ b/timegpt-docs/code-group-tab-labels.js
@@ -8,7 +8,7 @@
  * no title. Re-runs on client-side nav and when accordions reveal code groups.
  */
 (function () {
-  var FALLBACK = "Example code";
+  var FALLBACK = "Example";
 
   function labelTab(tab) {
     var titleBox = tab.querySelector('[class*="peer/title"]');
@@ -18,7 +18,7 @@
     var fn =
       panel &&
       panel.querySelector(
-        '[data-component-part="code-block-header-filename"] span'
+        '[data-component-part="code-block-header-filename"] span',
       );
     var text = (fn && fn.textContent.trim()) || FALLBACK;
 
@@ -32,9 +32,7 @@
   }
 
   function run() {
-    document
-      .querySelectorAll('.code-group [role="tab"]')
-      .forEach(labelTab);
+    document.querySelectorAll('.code-group [role="tab"]').forEach(labelTab);
   }
 
   var scheduled = false;

--- a/timegpt-docs/code-group-tab-labels.js
+++ b/timegpt-docs/code-group-tab-labels.js
@@ -48,8 +48,24 @@
   if (document.readyState !== "loading") run();
   else document.addEventListener("DOMContentLoaded", run);
 
+  // Only an element insertion can introduce a code-group, so skip mutations that
+  // add nothing but text nodes — keeps text-heavy reference pages from scheduling
+  // a full-document scan on every streamed character. (run() is still rAF-debounced
+  // and the label.textContent guard stops the self-triggered append from looping.)
+  function onMutations(records) {
+    for (var i = 0; i < records.length; i++) {
+      var added = records[i].addedNodes;
+      for (var j = 0; j < added.length; j++) {
+        if (added[j].nodeType === 1) {
+          schedule();
+          return;
+        }
+      }
+    }
+  }
+
   // Re-run when tabs/panels mount late (hydration, client-side nav, accordions).
-  new MutationObserver(schedule).observe(document.body, {
+  new MutationObserver(onMutations).observe(document.body, {
     childList: true,
     subtree: true,
   });

--- a/timegpt-docs/code-group-tab-labels.js
+++ b/timegpt-docs/code-group-tab-labels.js
@@ -1,0 +1,58 @@
+/*
+ * Code-group tabs: show the block's label next to the icon.
+ *
+ * Mintlify renders each code-group tab as an icon only; the human label lives in
+ * the tab's panel header ([data-component-part="code-block-header-filename"]).
+ * CSS can't copy text across elements, so we mirror each panel's filename into
+ * its tab (next to the icon), falling back to "Example code" when the block has
+ * no title. Re-runs on client-side nav and when accordions reveal code groups.
+ */
+(function () {
+  var FALLBACK = "Example code";
+
+  function labelTab(tab) {
+    var titleBox = tab.querySelector('[class*="peer/title"]');
+    if (!titleBox) return;
+
+    var panel = document.getElementById(tab.getAttribute("aria-controls"));
+    var fn =
+      panel &&
+      panel.querySelector(
+        '[data-component-part="code-block-header-filename"] span'
+      );
+    var text = (fn && fn.textContent.trim()) || FALLBACK;
+
+    var label = titleBox.querySelector("[data-cg-label]");
+    if (!label) {
+      label = document.createElement("span");
+      label.setAttribute("data-cg-label", "");
+      titleBox.appendChild(label);
+    }
+    if (label.textContent !== text) label.textContent = text;
+  }
+
+  function run() {
+    document
+      .querySelectorAll('.code-group [role="tab"]')
+      .forEach(labelTab);
+  }
+
+  var scheduled = false;
+  function schedule() {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(function () {
+      scheduled = false;
+      run();
+    });
+  }
+
+  if (document.readyState !== "loading") run();
+  else document.addEventListener("DOMContentLoaded", run);
+
+  // Re-run when tabs/panels mount late (hydration, client-side nav, accordions).
+  new MutationObserver(schedule).observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+})();

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -71,6 +71,12 @@
   /* Accordion surface */
   --accordion-bg: #ffffff;
 
+  /* Chat assistant */
+  --chat-input-bg: #ffffff;
+  --chat-shadow:
+    0 1px 6px 0 rgba(0, 0, 0, 0.06), 0 2px 32px 0 rgba(0, 0, 0, 0.16);
+  --chat-launcher-gap: 72px; /* mobile: room reserved for the Intercom launcher */
+
   --code-group-bg: #000000;
   --code-group-border: var(--blog-code-border);
 
@@ -175,6 +181,9 @@ html.dark {
 
   /* Accordion surface */
   --accordion-bg: #000000;
+
+  /* Chat assistant */
+  --chat-input-bg: #000000;
 
   --code-group-bg: #000000;
   --code-group-border: var(--blog-code-border);
@@ -1873,6 +1882,50 @@ details.expandable .primitive-param-field {
 
 .chat-assistant-floating-input::before {
   background-color: transparent !important;
+}
+
+/* Chat input box (the rounded container wrapping the textarea): solid tokenized
+   bg (#fff / #000), pill radius + the Intercom launcher shadow so it reads as
+   part of the same control family. Targeted via the textarea's box ancestor. */
+div:has(> div > #chat-assistant-textarea) {
+  background-color: var(--chat-input-bg) !important;
+  border-radius: 9999px !important;
+  box-shadow: var(--chat-shadow) !important;
+}
+
+/* Textarea itself stays transparent over the box bg. */
+.chat-assistant-input {
+  background-color: transparent !important;
+}
+
+/* The sticky wrapper around the chat input has overflow:hidden, which clips the
+   pill's box-shadow into a rectangle. Let it overflow so the rounded shadow
+   renders fully. */
+div:has(> .chat-assistant-floating-input) {
+  overflow: visible !important;
+}
+
+/* Send button: --alt surface with --primary-foreground icon (beats the inline
+   background:black and the bg-primary utility). */
+.chat-assistant-send-button {
+  background: var(--alt) !important;
+}
+
+.chat-assistant-send-button svg {
+  color: var(--primary-foreground) !important;
+}
+
+/* Mobile: place the input and the Intercom launcher on one row — input fills the
+   width minus the launcher's reserved space on the right (~80/20). NOTE: the
+   Intercom launcher is a separate fixed widget that only renders in the live
+   env; fine-tune --chat-launcher-gap there. */
+@media (max-width: 767px) {
+  div:has(> div > #chat-assistant-textarea) {
+    width: auto !important; /* override w-full so margin-right actually reserves space */
+    max-width: none !important;
+    margin-left: 0 !important;
+    margin-right: var(--chat-launcher-gap) !important;
+  }
 }
 
 /* ==============================  UTILITIES  =============================== */

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -1070,26 +1070,13 @@ html:not(.dark) .code-block .shiki span {
 
 body .code-group {
   border-radius: 0 !important;
-  background-color: var(--code-group-bg) !important;
+  background-color: transparent !important;
   border: 1px solid var(--code-group-border) !important;
-  padding: var(--space-16) !important;
+  padding: 0px !important;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
   position: relative;
   isolation: isolate;
-}
-
-body .code-group::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
-  background-repeat: repeat;
-  background-size: var(--grain-size);
-  filter: grayscale(1) contrast(1.5);
-  opacity: var(--grain-opacity);
 }
 
 .code-group .code-block {
@@ -1097,8 +1084,16 @@ body .code-group::after {
   margin: 0 !important;
 }
 
+.code-group [data-component-part="code-group-tab-bar"] {
+  background-color: var(--blog-code-header-bg) !important;
+  padding: var(--space-6) 0 !important;
+  border-top: 1px solid var(--blog-code-border) !important;
+  border-right: 1px solid var(--blog-code-border) !important;
+  border-left: 1px solid var(--blog-code-border) !important;
+}
+
 .code-group [data-component-part="code-group-tab-bar"] + div {
-  margin-top: var(--space-16) !important;
+  margin-top: 0px !important;
 }
 
 @layer utilities {
@@ -1803,6 +1798,32 @@ details.accordion {
   border-color: var(--border) !important;
 }
 
+/* Open/close animation. ::details-content is the generated wrapper around the
+   non-summary content; interpolate-size lets its height:auto animate. overflow
+   hidden clips during the slide and prevents the content margins collapsing out.
+   Degrades to an instant toggle where ::details-content isn't supported. */
+details.accordion {
+  interpolate-size: allow-keywords;
+}
+
+details.accordion::details-content {
+  height: 0;
+  overflow: hidden;
+  transition:
+    height var(--duration-slow) var(--ease-in-out),
+    content-visibility var(--duration-slow) var(--ease-in-out) allow-discrete;
+}
+
+details.accordion[open]::details-content {
+  height: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  details.accordion::details-content {
+    transition: none;
+  }
+}
+
 [data-component-part="tab-content"] > details.accordion + details.accordion {
   margin-top: calc(-1 * var(--space-20)) !important;
   border-top: none !important;
@@ -2104,6 +2125,19 @@ details.expandable .primitive-param-field {
 
 [role="menu"][data-orientation="vertical"] [role="menuitem"]:hover {
   background-color: var(--dropdown-hover) !important;
+}
+
+/* Check indicator: only the active item shows it. Mintlify hides inactive checks
+   with text-primary/0, but that utility doesn't resolve to transparent here, so the
+   check inherits the item's gray text and all three appear checked. Force the check
+   transparent on non-active items (data-active marks the active one). Targets the
+   stable .theme-preference-menu-item class — this base-ui menu has no
+   data-orientation, so [data-orientation] selectors don't match it. */
+.theme-preference-menu-item:not([data-active="true"]) > svg[aria-hidden="true"],
+.theme-preference-menu-item:not([data-active="true"])
+  > svg[aria-hidden="true"]
+  * {
+  color: transparent !important;
 }
 
 #page-context-menu-button,

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -2146,8 +2146,10 @@ details.expandable .primitive-param-field {
 
 /* Desktop assistant panel: solid #fff / #000 surface (the mobile drawer —
    [role="dialog"] — keeps its default background). Covers both the inner sheet
-   and its outer sticky wrapper so no cream shows behind it. */
-.chat-assistant-sheet:not([role="dialog"]),
+   and its outer sticky wrapper so no cream shows behind it. The #id selector is
+   needed to outrank the global html:not(.dark) .bg-background-light rule (0,2,1),
+   which otherwise repaints the sheet with --background (cream). */
+#chat-assistant-sheet:not([role="dialog"]),
 div:has(> #chat-assistant-sheet) {
   background-color: var(--chat-input-bg) !important;
 }

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -2048,6 +2048,11 @@ details.expandable .primitive-param-field {
 
 /* ===========================  FEEDBACK TOOLBAR  =========================== */
 
+/* Drop Mintlify's pb-16 (64px) below the toolbar. */
+.feedback-toolbar {
+  padding-bottom: 0px !important;
+}
+
 .feedback-toolbar p {
   color: var(--primary) !important;
   font-family: var(--font-sans) !important;

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -1071,7 +1071,7 @@ html:not(.dark) .code-block .shiki span {
 body .code-group {
   border-radius: 0 !important;
   background-color: transparent !important;
-  border: 1px solid var(--code-group-border) !important;
+  border: none !important;
   padding: 0px !important;
   margin-top: 0 !important;
   margin-bottom: 0 !important;

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -45,7 +45,7 @@
 
   --code-block-radius: 0;
 
-  --page-title-max-width: 30rem;
+  --page-title-max-width: 35rem;
 
   --image-link-badge-height: 28px;
 
@@ -1889,7 +1889,7 @@ details.expandable .primitive-param-field {
    part of the same control family. Targeted via the textarea's box ancestor. */
 div:has(> div > #chat-assistant-textarea) {
   background-color: var(--chat-input-bg) !important;
-  border-radius: 9999px !important;
+  border-radius: 0px !important;
   box-shadow: var(--chat-shadow) !important;
 }
 
@@ -1903,6 +1903,15 @@ div:has(> div > #chat-assistant-textarea) {
    renders fully. */
 div:has(> .chat-assistant-floating-input) {
   overflow: visible !important;
+}
+
+/* Intercom launcher: 60px, theme-aware surface (#fff / #000). Target the stable
+   .intercom-launcher class only — Intercom's hashed classes (e.g. intercom-…)
+   change per build. !important to beat Intercom's runtime-injected CSS. */
+.intercom-launcher {
+  width: 60px !important;
+  height: 60px !important;
+  background: var(--chat-input-bg) !important;
 }
 
 /* Send button: --alt surface with --primary-foreground icon (beats the inline

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -34,6 +34,7 @@
   --background: #f6f4f0;
   --primary: #222121;
   --primary-foreground: #f6f4f0;
+  --primary-muted: #22212195; /* muted — secondary UI color */
 
   /* Website button parity */
   --alt: #222121;
@@ -68,6 +69,13 @@
   --dropdown-text: var(--secondary-foreground);
   --dropdown-border: var(--card-border);
 
+  /* Accordion surface */
+  --accordion-bg: #ffffff;
+
+  /* Code group surface */
+  --code-group-bg: #ffffff;
+  --code-group-border: rgba(0, 0, 0, 0.1);
+
   /* Buttons */
   --button-height: 34px;
 }
@@ -78,6 +86,7 @@ html.dark {
   --background: #222121;
   --primary: #dedddd;
   --primary-foreground: #222121;
+  --primary-muted: #dedddd95; /* muted — secondary UI color */
 
   /* Website button parity */
   --alt: #f6f4f0;
@@ -110,6 +119,13 @@ html.dark {
   --dropdown-bg: var(--secondary);
   --dropdown-text: var(--secondary-foreground);
   --dropdown-border: var(--secondary);
+
+  /* Accordion surface */
+  --accordion-bg: #000000;
+
+  /* Code group surface */
+  --code-group-bg: #000000;
+  --code-group-border: rgba(255, 255, 255, 0.1);
 }
 
 /* Base */
@@ -119,6 +135,12 @@ body {
   background-color: var(--background);
   font-family: "NeueMontreal", sans-serif;
   font-weight: 400;
+}
+
+/* Smooth scroll for in-page anchors (TOC clicks). <html> is the scroll
+   container; headings already carry scroll-margin-top for the navbar offset. */
+html {
+  scroll-behavior: smooth;
 }
 
 html.dark > body {
@@ -206,6 +228,17 @@ html.dark #navbar-transition {
   line-height: 92%;
 }
 
+/* Navbar CTA group: 8px gap between buttons + 8px from the right edge.
+   Neutralize Tailwind `space-x-2` (margin-based) so `gap` is the only spacing. */
+#navbar nav ul {
+  gap: 8px !important;
+  margin-inline-end: 8px !important;
+}
+
+#navbar nav ul > li {
+  margin: 0 !important;
+}
+
 /* "Book a meeting" — outline */
 #navbar nav li:not(#topbar-cta-button) a {
   height: var(--button-height) !important;
@@ -255,6 +288,106 @@ html.dark #navbar-transition {
 
 #topbar-cta-button svg {
   color: var(--primary-foreground) !important;
+}
+
+/* ── Navbar button hover text-shift ─────────────────────────────────────────
+   Ports the website's `.button-text-shift` effect. That component reads the
+   label from `data-hover-label` (`content: attr(...)`), set by JS. Mintlify's
+   navbar HTML is fixed — we can't add data attributes, and CSS `content`
+   cannot read an element's text, so we hardcode each label.
+
+   Mechanism (same as the component): the real text is made transparent so it
+   only holds the button's width, and TWO full-size pseudo layers carry the
+   visible label — `::before` sits in place, `::after` waits one box below. On
+   hover both slide up exactly one box: `::before` exits the top, `::after`
+   lands in place. Both layers cover the same box, so translateY(±100%) always
+   clears the clip cleanly (the earlier bug: translating the small text line by
+   its own height didn't clear the taller button, leaving both labels stacked). */
+
+/* Outline buttons — "Book a meeting" and the mobile-only "Get Started".
+   No icon, so the overlay fills the whole button; only the label differs. */
+#navbar nav li:not(#topbar-cta-button) a {
+  position: relative !important;
+  overflow: hidden !important;
+}
+
+/* Real text kept for width + accessible name, but hidden. */
+#navbar nav li:not(#topbar-cta-button) a > span {
+  color: transparent;
+}
+
+#navbar nav li:not(#topbar-cta-button) a::before,
+#navbar nav li:not(#topbar-cta-button) a::after {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary);
+  transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#navbar nav li:not(#topbar-cta-button) a::before {
+  transform: translateY(0);
+}
+
+#navbar nav li:not(#topbar-cta-button) a::after {
+  transform: translateY(100%);
+}
+
+#navbar nav li:not(#topbar-cta-button) a:hover::before {
+  transform: translateY(-100%);
+}
+
+#navbar nav li:not(#topbar-cta-button) a:hover::after {
+  transform: translateY(0);
+}
+
+/* Per-button labels (CSS `content` can't read the element's text). */
+#navbar nav li.navbar-link a::before,
+#navbar nav li.navbar-link a::after {
+  content: "Book a meeting";
+}
+
+#navbar nav li:not(.navbar-link):not(#topbar-cta-button) a::before,
+#navbar nav li:not(.navbar-link):not(#topbar-cta-button) a::after {
+  content: "Get Started";
+}
+
+/* "Get Started" (primary CTA) keeps its arrow icon, so the swap is scoped to
+   the text `span` (a full-button overlay would sit on top of the arrow — the
+   same reason the React component bails on icon buttons). The span is its own
+   clip box, so the two layers swap within the text's height and the arrow
+   stays put. */
+#topbar-cta-button a div > span {
+  position: relative;
+  overflow: hidden;
+  color: transparent;
+}
+
+#topbar-cta-button a div > span::before,
+#topbar-cta-button a div > span::after {
+  content: "Get Started";
+  position: absolute;
+  inset: 0;
+  color: var(--primary-foreground);
+  transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#topbar-cta-button a div > span::before {
+  transform: translateY(0);
+}
+
+#topbar-cta-button a div > span::after {
+  transform: translateY(100%);
+}
+
+#topbar-cta-button a:hover div > span::before {
+  transform: translateY(-100%);
+}
+
+#topbar-cta-button a:hover div > span::after {
+  transform: translateY(0);
 }
 
 /* CTA — secondary */
@@ -352,6 +485,11 @@ div:has(> div > #navigation-items) {
   background-color: var(--background) !important;
 }
 
+/* Sidebar group header (e.g. INTRODUCTION): 500, not 600. */
+.sidebar-group-header {
+  font-weight: 400 !important;
+}
+
 #sidebar-title {
   padding: 8px !important;
 }
@@ -369,20 +507,32 @@ div:has(> div > #navigation-items) {
 
 /* Inactive icon = muted */
 #navigation-items .sidebar-group a svg {
-  background-color: color-mix(in srgb, var(--primary) 60%, transparent) !important;
+  background-color: color-mix(
+    in srgb,
+    var(--primary) 60%,
+    transparent
+  ) !important;
 }
 
 /* Hover */
 #navigation-items .sidebar-group a:hover,
 #navigation-items .sidebar-group button:hover {
-  background-color: color-mix(in srgb, var(--primary) 8%, transparent) !important;
+  background-color: color-mix(
+    in srgb,
+    var(--primary) 8%,
+    transparent
+  ) !important;
   color: var(--primary) !important;
 }
 
 /* Active page indicator */
 #navigation-items .sidebar-group a[class*="bg-primary"] {
   border-left-color: var(--primary) !important;
-  background-color: color-mix(in srgb, var(--primary) 8%, transparent) !important;
+  background-color: color-mix(
+    in srgb,
+    var(--primary) 8%,
+    transparent
+  ) !important;
   color: var(--primary) !important;
 }
 
@@ -454,9 +604,10 @@ pre code {
   border-radius: 0 !important;
 }
 
-/* Force dark tokens in light */
-html:not(.dark) .code-block .shiki,
-html:not(.dark) .code-block .shiki span {
+/* Force dark tokens in light (standalone blocks only; code groups are themed
+   #fff/#000 and keep the native light syntax theme in light mode). */
+html:not(.dark) .code-block:not(.code-group *) .shiki,
+html:not(.dark) .code-block:not(.code-group *) .shiki span {
   color: var(--shiki-dark) !important;
 }
 
@@ -483,7 +634,113 @@ html:not(.dark) .code-block .shiki span {
   background-color: rgba(246, 244, 240, 0.08) !important;
 }
 
+/* Code group (tabbed code blocks) */
+
+/* Themed surface (#fff light / #000 dark), sharp corners — our design.
+   `body` prefix so it out-specifies the global .rounded-2xl utility. */
+body .code-group,
+.code-group [data-component-part="code-block-root"],
+.code-group pre.shiki,
+.code-group .code-block {
+  border-radius: 0 !important;
+}
+
+.code-group {
+  background-color: var(--code-group-bg) !important;
+  border: 1px solid var(--code-group-border) !important;
+}
+
+/* Code surface = themed; keep native syntax theme per mode (light theme on
+   #fff, dark theme on #000). Plain (unspanned) text uses --primary. */
+.code-group [data-component-part="code-block-root"],
+.code-group pre.shiki {
+  background-color: var(--code-group-bg) !important;
+  --shiki-dark-bg: #000000 !important;
+  color: var(--primary) !important;
+}
+
+/* Filename header + nested block chrome themed */
+.code-group [data-component-part="code-block-header"] {
+  background-color: var(--code-group-bg) !important;
+  border-bottom-color: var(--code-group-border) !important;
+}
+
+.code-group .code-block {
+  background: transparent !important;
+  border: 0 !important;
+}
+
+.code-group [data-fade-overlay] {
+  --fade-color-light: #ffffff !important;
+  --fade-color-dark: #000000 !important;
+}
+
+/* Tabs: active = --primary, inactive = --primary-muted */
+.code-group [role="tab"] {
+  color: var(--primary-muted) !important;
+}
+
+.code-group [role="tab"][aria-selected="true"] {
+  color: var(--primary) !important;
+}
+
+.code-group [role="tab"] svg {
+  background-color: currentColor !important;
+}
+
+/* Active-tab underline indicator = --primary */
+.code-group [role="tab"] [class*="bg-primary"] {
+  background-color: var(--primary) !important;
+}
+
+/* Hide the group-level copy button (far right of the tab bar); each block still
+   has its own copy button in its header. */
+.code-group
+  > [data-component-part="code-group-tab-bar"]
+  [data-testid="copy-code-button"] {
+  display: none !important;
+}
+
 /* TOC */
+
+/* Table of contents: inactive items use --primary-muted, the active item (and
+   hover) uses --primary. */
+#table-of-contents-content a,
+.toc a {
+  color: var(--primary-muted) !important;
+  transition: color 0.15s ease;
+}
+
+#table-of-contents-content a:hover,
+.toc a:hover,
+#table-of-contents-content .toc-item[data-active="true"] > a,
+#table-of-contents-content a[aria-current="location"],
+.toc a[aria-current="location"] {
+  color: var(--primary) !important;
+}
+
+/* The "mint" theme doesn't render the vertical rail that other Mintlify themes
+   (e.g. Greptile's) draw next to the TOC, so we build it here: a faint left
+   border on every item, highlighted on the active one — that's the "you are
+   here" indicator. Border lives on the <li> so anchor padding keeps the
+   existing depth indentation. */
+#table-of-contents-content .toc-item {
+  border-left: 1.5px solid color-mix(in srgb, var(--primary) 14%, transparent);
+  padding-left: 0.75rem;
+  transition: border-color 0.15s ease;
+}
+
+#table-of-contents-content .toc-item[data-active="true"] {
+  border-left-color: var(--primary);
+}
+
+/* Subtle weight on the active label so it reads clearly even though --primary
+   is grayscale (mirrors Greptile's text-shadow trick). */
+#table-of-contents-content .toc-item[data-active="true"] > a,
+#table-of-contents-content a[aria-current="location"],
+.toc a[aria-current="location"] {
+  text-shadow: -0.15px 0 0 currentColor, 0.15px 0 0 currentColor;
+}
 
 /* Content layout */
 
@@ -571,7 +828,7 @@ details.accordion :not(summary) span[data-as="p"] {
 
 #content-side-layout a.font-medium {
   color: var(--primary);
-  font-weight: 600;
+  font-weight: 500;
 }
 
 /* Cards */
@@ -688,6 +945,13 @@ details.accordion summary {
   border-radius: 0 !important;
 }
 
+/* Accordion surface: #fff (light) / #000 (dark). Needs html:not(.dark)/html.dark
+   to out-specify the global `.bg-background-light` override, which is (0,2,1). */
+html:not(.dark) details.accordion,
+html.dark details.accordion {
+  background-color: var(--accordion-bg) !important;
+}
+
 details.accordion summary:hover {
   background-color: var(--secondary) !important;
 }
@@ -702,6 +966,13 @@ html.dark details.accordion summary:hover {
 [data-component-part="step-number"] > div {
   background-color: var(--primary) !important;
   color: var(--primary-foreground) !important;
+}
+
+/* Step icon/number sits on the --primary badge, so it must use the foreground
+   token — otherwise the icon (bg-gray-900) is dark-on-dark and invisible
+   (e.g. steps inside an accordion). */
+[data-component-part="step-number"] > div svg {
+  background-color: var(--primary-foreground) !important;
 }
 
 /* Tables — blog parity */
@@ -1009,6 +1280,55 @@ a {
   border-radius: calc(var(--radius) + 0.125rem) !important;
 }
 
+/* Mobile sidebar & iOS safe areas */
+
+/* Mintlify paints a full-viewport fixed <span id="background-color"> using its
+   built-in white background token (bg-background-light). On iOS 26 Safari the
+   status-bar/toolbar tint is sampled from a fixed element's background-color,
+   so this white layer is what makes the bar show white / look transparent with
+   content bleeding under the notch. Repaint it (and the token utilities) with
+   our canvas so every candidate Safari can sample is --background. */
+#background-color,
+.bg-background-light,
+html:not(.dark) .bg-background-light {
+  background-color: var(--background) !important;
+}
+
+html.dark #background-color,
+html.dark .bg-background-dark,
+.dark\:bg-background-dark {
+  background-color: var(--background) !important;
+}
+
+/* Paint the mobile sidebar scroll container as canvas (was white).
+   Scoped to the sidebar so code-block scroll areas keep their own bg. */
+#sidebar,
+#sidebar-content,
+#sidebar [data-component-part^="scroll-area"],
+#sidebar-content [data-component-part^="scroll-area"],
+[data-component-part="scroll-area"]:has(#navigation-items),
+[data-component-part="scroll-area"]:has(#navigation-items)
+  [data-component-part^="scroll-area"] {
+  background-color: var(--background) !important;
+}
+
+/* Keep the scrollbar thumb visible over the canvas */
+#sidebar [data-component-part="scroll-area-scrollbar"],
+#sidebar-content [data-component-part="scroll-area-scrollbar"],
+[data-component-part="scroll-area"]:has(#navigation-items)
+  [data-component-part="scroll-area-scrollbar"] {
+  background-color: transparent !important;
+}
+
+/* Mobile navbar: opaque canvas (like the site), matching how the working
+   default Mintlify docs rely on solid top layers. */
+@media (max-width: 1023px) {
+  #navbar,
+  #navbar-transition {
+    background-color: var(--background) !important;
+  }
+}
+
 /* Film grain (nixtla.io noise) */
 
 :root {
@@ -1018,9 +1338,16 @@ a {
 
 body::after {
   content: "";
+  /* Fixed so the grain stays static while content scrolls (no "chasing" — that
+     was an `absolute`-only artifact), but BELOW the chrome (navbar z-30, sticky
+     bars z-20) and above content. This keeps the opaque navbar as the top layer
+     at the notch, so iOS 26 Safari samples IT (canvas) for the status bar tint
+     instead of this near-transparent grain — which is what made content bleed
+     through. The grain therefore only overlays the reading area, never the
+     navbar/breadcrumb chrome. */
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  z-index: 10;
   pointer-events: none;
   /* both roots: / and /docs */
   background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
@@ -1030,9 +1357,48 @@ body::after {
   opacity: var(--grain-opacity);
 }
 
+/* Reusable grain layer for a specific block.
+   Unlike the full-viewport body::after, this is a grain overlay SCOPED to a
+   single element (absolute, inset:0). Because it lives inside its block and is
+   not a separate fixed full-viewport layer, it never becomes the element iOS 26
+   samples for the status-bar tint. Add `grain-layer` to any block, or use the
+   selectors below. Applied to #navbar, which on mobile also contains the
+   breadcrumb/hamburger bar — so both get grain in one shot. */
+.grain-layer {
+  position: relative;
+}
+
+.grain-layer::after,
+#navbar::after,
+#banner::after,
+#sidebar::after,
+#mobile-nav::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
+  background-repeat: repeat;
+  background-size: var(--grain-size);
+  filter: grayscale(1) contrast(1.5);
+  opacity: var(--grain-opacity);
+}
+
+/* The desktop sidebar's inner content (#sidebar-content) is z-10, so its grain
+   must sit above that to be visible. */
+#sidebar::after {
+  z-index: 11;
+}
+
 /* Opt out for high contrast */
 @media (prefers-contrast: more) {
-  body::after {
+  body::after,
+  .grain-layer::after,
+  #navbar::after,
+  #banner::after,
+  #sidebar::after,
+  #mobile-nav::after {
     display: none;
   }
 }

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -449,11 +449,71 @@ html.dark #navbar-transition {
   transform: translateY(0);
 }
 
+/* "Ask Assistant" toolbar button — outline variant (like "Book a meeting") with
+   the same hover text-shift. Shift scoped to the label span so the sparkle icon
+   stays put. box-shadow/filter reset kills the ring + dark:brightness. */
+#assistant-entry {
+  background: var(--background) !important;
+  border: 1px solid var(--border) !important;
+  box-shadow: none !important;
+  filter: none !important;
+  color: var(--primary) !important;
+  transition: var(--transition-hover) !important;
+  position: relative !important;
+  overflow: hidden !important;
+}
+
+#assistant-entry:hover {
+  background: var(--hover) !important;
+}
+
+#assistant-entry svg {
+  color: var(--primary) !important;
+}
+
+#assistant-entry span {
+  position: relative;
+  overflow: hidden;
+  color: transparent !important;
+}
+
+#assistant-entry span::before,
+#assistant-entry span::after {
+  content: "Ask Assistant";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  color: var(--primary);
+  transition: transform var(--duration-shift) var(--ease-standard);
+  pointer-events: none;
+}
+
+#assistant-entry span::before {
+  transform: translateY(0);
+}
+
+#assistant-entry span::after {
+  transform: translateY(115%);
+}
+
+#assistant-entry:is(:hover, :focus-visible) span::before {
+  transform: translateY(-115%);
+}
+
+#assistant-entry:is(:hover, :focus-visible) span::after {
+  transform: translateY(0);
+}
+
 @media (prefers-reduced-motion: reduce) {
   #navbar nav li:not(#topbar-cta-button) a::before,
   #navbar nav li:not(#topbar-cta-button) a::after,
   #topbar-cta-button a div > span::before,
-  #topbar-cta-button a div > span::after {
+  #topbar-cta-button a div > span::after,
+  #assistant-entry span::before,
+  #assistant-entry span::after {
     transition: none;
   }
 }
@@ -2029,6 +2089,7 @@ body::after {
 #sidebar::after,
 #mobile-nav::after,
 #search-bar-entry::after,
+.chat-assistant-sheet::after,
 [data-radix-menu-content]::after,
 [data-component-part="theme-preference-menu-content"]::after,
 [role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {
@@ -2056,6 +2117,7 @@ body::after {
   #sidebar::after,
   #mobile-nav::after,
   #search-bar-entry::after,
+  .chat-assistant-sheet::after,
   [data-radix-menu-content]::after,
   [data-component-part="theme-preference-menu-content"]::after,
   [role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -2140,8 +2140,10 @@ details.expandable .primitive-param-field {
 }
 
 /* Desktop assistant panel: solid #fff / #000 surface (the mobile drawer —
-   [role="dialog"] — keeps its default background). */
-.chat-assistant-sheet:not([role="dialog"]) {
+   [role="dialog"] — keeps its default background). Covers both the inner sheet
+   and its outer sticky wrapper so no cream shows behind it. */
+.chat-assistant-sheet:not([role="dialog"]),
+div:has(> #chat-assistant-sheet) {
   background-color: var(--chat-input-bg) !important;
 }
 
@@ -2329,6 +2331,7 @@ body::after {
 #assistant-entry::after,
 .chat-assistant-sheet::after,
 [data-component-part="search-modal"]::after,
+[data-component-part="search-input-container"]::after,
 [data-radix-menu-content]::after,
 [data-component-part="theme-preference-menu-content"]::after,
 [role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {
@@ -2348,6 +2351,11 @@ body::after {
   z-index: 11;
 }
 
+/* Grain follows the input's rounded-2xl so it doesn't poke past the corners. */
+[data-component-part="search-input-container"]::after {
+  border-radius: inherit;
+}
+
 @media (prefers-contrast: more) {
   body::after,
   .grain-layer::after,
@@ -2359,6 +2367,7 @@ body::after {
   #assistant-entry::after,
   .chat-assistant-sheet::after,
   [data-component-part="search-modal"]::after,
+  [data-component-part="search-input-container"]::after,
   [data-radix-menu-content]::after,
   [data-component-part="theme-preference-menu-content"]::after,
   [role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -1,4 +1,4 @@
-/* Fonts */
+/* ================================  FONTS  ================================= */
 
 @font-face {
   font-family: "NeueMontreal";
@@ -16,44 +16,42 @@
 
 @font-face {
   font-family: "Supply";
-  src: url("/fonts/PPSupplyMono-Ultralight.woff2") format("woff2");
-  font-weight: 200;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "Supply";
   src: url("/fonts/PPSupplyMono-Regular.woff2") format("woff2");
   font-weight: 400;
   font-display: swap;
 }
 
-/* Tokens — light */
+/* ============================  TOKENS · LIGHT  ============================ */
 
 :root {
   --background: #f6f4f0;
   --primary: #222121;
   --primary-foreground: #f6f4f0;
-  --primary-muted: #22212195; /* muted — secondary UI color */
+  --primary-muted: #22212195;
 
-  /* Website button parity */
   --alt: #222121;
-  --hover-alt: #2e2b27;
   --surface: #eae9e6;
+
+  --hover: var(--surface);
+  --hover-alt: #2e2b27;
+  --nav-tint: color-mix(in srgb, var(--primary) 8%, transparent);
+  --toc-rail: color-mix(in srgb, var(--primary) 14%, transparent);
 
   --secondary: #ececec;
   --secondary-foreground: #222121;
   --border: #222121;
-  --accent: #bfd1ff;
+  --accent: #bfd1ff; /* brand accent */
   --radius: 0rem;
 
-  /* Active nav item */
-  --active-nav-item: #d9d9d9;
+  --code-block-radius: 0;
+
+  --page-title-max-width: 30rem;
+
+  --image-link-badge-height: 28px;
 
   /* Card */
   --card-bg: rgba(252, 252, 252, 0.5);
-  --card-bg-hover: rgba(245, 245, 245, 0.9);
-  --card-border: var(--secondary);
+  --card-border: var(--primary);
 
   /* Feedback toolbar */
   --feedback-btn-bg: var(--secondary);
@@ -68,43 +66,97 @@
   --dropdown-bg: #ffffff;
   --dropdown-text: var(--secondary-foreground);
   --dropdown-border: var(--card-border);
+  --dropdown-hover: var(--hover);
 
   /* Accordion surface */
   --accordion-bg: #ffffff;
 
-  /* Code group surface */
-  --code-group-bg: #ffffff;
-  --code-group-border: rgba(0, 0, 0, 0.1);
+  --code-group-bg: #000000;
+  --code-group-border: var(--blog-code-border);
+
+  /* Code palette (always-dark frame, both themes) */
+  --blog-code-bg: #171614;
+  --blog-code-header-bg: #201f1d;
+  --blog-code-border: rgba(246, 244, 240, 0.22);
+  --blog-code-text: #f4f1ea;
+  --blog-code-muted: rgba(244, 241, 234, 0.62);
+  --code-hover-overlay: rgba(246, 244, 240, 0.08);
+  --code-tab-hover: #2e2b27;
 
   /* Buttons */
   --button-height: 34px;
+
+  /* Motion */
+  --ease-standard: ease;
+  --duration-fast: 0.15s;
+  --duration-base: 0.2s;
+  --duration-shift: 220ms;
+  --transition-hover: background-color var(--duration-base) var(--ease-standard);
+
+  /* FONTS */
+  --font-sans: "NeueMontreal", sans-serif;
+  --font-mono: "Supply", monospace;
+
+  /* FONTS WEIGHT */
+  --font-weight-regular: 400;
+  /* Override medium from mintlify to our own 400 weight instead of changing it in mintlify classes, our DLS only uses 400 weight */
+  --font-weight-medium: 400;
+  --font-weight-semibold: 400;
+
+  /* SPACE TOKENS */
+  --space-2: 0.125rem;
+  --space-4: 0.25rem;
+  --space-6: 0.375rem;
+  --space-8: 0.5rem;
+  --space-10: 0.625rem;
+  --space-12: 0.75rem;
+  --space-14: 0.875rem;
+  --space-16: 1rem;
+  --space-20: 1.25rem;
+  --space-24: 1.5rem;
+  --space-32: 2rem;
+  --space-40: 2.5rem;
+  --space-48: 3rem;
+  --space-56: 3.5rem;
+  --space-64: 4rem;
+
+  /* SPACING LAYOUT */
+  --spacing-header-description: var(--space-8);
+  --spacing-content-area: var(--space-40);
+  --spacing-footer-top: var(--space-20);
+  --spacing-component-top: var(--space-20);
+
+  /* SPACING MDX CONTENT */
+  --spacing-mdx-content: var(--space-20);
+  --spacing-mdx-content-prose-headers: var(--space-32);
+  --spacing-mdx-content-prose-headers-small: var(--space-20);
+  --spacing-mdx-content-prose-li: var(--space-8);
+
+  --spacing-list-steps-gap: var(--space-40);
 }
 
-/* Tokens — dark */
+/* ============================  TOKENS · DARK  ============================= */
 
 html.dark {
   --background: #222121;
   --primary: #dedddd;
   --primary-foreground: #222121;
-  --primary-muted: #dedddd95; /* muted — secondary UI color */
+  --primary-muted: #dedddd95;
 
-  /* Website button parity */
   --alt: #f6f4f0;
-  --hover-alt: #eae9e6;
   --surface: #2e2b27;
+
+  --hover: var(--surface);
+  --hover-alt: #eae9e6;
 
   --secondary: #ececec;
   --secondary-foreground: #222121;
   --border: rgba(212, 212, 216, 0.6);
   --accent: #9187e8;
 
-  /* Active nav item */
-  --active-nav-item: rgba(222, 221, 221, 0.1);
-
   /* Card */
   --card-bg: rgba(255, 255, 255, 0.03);
-  --card-bg-hover: rgba(255, 255, 255, 0.06);
-  --card-border: rgba(255, 255, 255, 0.08);
+  --card-border: var(--primary);
 
   /* Feedback toolbar */
   --feedback-btn-bg: rgba(255, 255, 255, 0.1);
@@ -116,29 +168,47 @@ html.dark {
   --table-border: var(--border);
 
   /* Dropdown */
-  --dropdown-bg: var(--secondary);
+  --dropdown-bg: var(--alt);
   --dropdown-text: var(--secondary-foreground);
   --dropdown-border: var(--secondary);
+  --dropdown-hover: var(--hover-alt);
 
   /* Accordion surface */
   --accordion-bg: #000000;
 
-  /* Code group surface */
   --code-group-bg: #000000;
-  --code-group-border: rgba(255, 255, 255, 0.1);
+  --code-group-border: var(--blog-code-border);
 }
 
-/* Base */
+/* =============================  SYSTEM NOTES  ============================= */
+
+/*
+  BREAKPOINTS (viewport px — var() is invalid in @media conditions):
+    640  min   header desktop layout
+    767  max   mobile (eyebrow-sm, banner)
+    991  max / 992 min   copy-page CTA swap (tablet <-> desktop)
+    1023 max   navbar bg on tablet-down
+  Reuse these exact values for new media queries.
+
+  MINTLIFY-COUPLED SELECTORS — re-verify on every Mintlify upgrade (they read
+  Mintlify's DOM shape or Tailwind utility classes, both of which can change):
+    div:has(> div > #navigation-items)           sidebar wrapper
+    [class*="bg-primary"]                         active nav / CTA state
+    #page-context-menu.ml-auto / .mt-3           copy-page CTA variants
+    #header .mt-2.text-lg / .w-full:not(table)   header + card utility hooks
+    #api-playground-2-operation-page .mt-6...    generated id + utility
+  Quick audit before upgrading: grep  :has(   [class*=   #api-playground
+*/
+
+/* =================================  BASE  ================================= */
 
 html,
 body {
   background-color: var(--background);
-  font-family: "NeueMontreal", sans-serif;
-  font-weight: 400;
+  font-family: var(--font-sans);
+  font-weight: var(--font-weight-regular);
 }
 
-/* Smooth scroll for in-page anchors (TOC clicks). <html> is the scroll
-   container; headings already carry scroll-margin-top for the navbar offset. */
 html {
   scroll-behavior: smooth;
 }
@@ -151,17 +221,18 @@ html.dark > body {
 h1 {
   font-size: 50px;
   font-style: normal;
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   line-height: 112%;
   letter-spacing: -0.5px;
   color: var(--primary);
+  max-width: var(--page-title-max-width);
 }
 
 h2,
 h2 span {
   font-size: 30px;
   font-style: normal;
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   line-height: 95%;
 }
 
@@ -169,13 +240,13 @@ p {
   color: var(--primary);
   font-size: 16px;
   font-style: normal;
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   line-height: 24px;
 }
 
 .eyebrow {
-  font-family: "Supply", monospace !important;
-  font-weight: 400 !important;
+  font-family: var(--font-mono) !important;
+  font-weight: var(--font-weight-regular) !important;
   font-size: 14px;
   text-transform: uppercase;
   font-stretch: expanded;
@@ -186,8 +257,8 @@ p {
 #sidebar-title,
 #table-of-contents button,
 #table-of-contents button span {
-  font-family: "Supply", monospace !important;
-  font-weight: 400 !important;
+  font-family: var(--font-mono) !important;
+  font-weight: var(--font-weight-regular) !important;
   font-size: 12px !important;
   text-transform: uppercase;
   font-stretch: expanded;
@@ -203,7 +274,7 @@ p {
   }
 }
 
-/* Navbar */
+/* ================================  NAVBAR  ================================ */
 
 #navbar img,
 .nav-logo {
@@ -220,29 +291,22 @@ html.dark #navbar-transition {
 }
 
 #navbar nav a {
-  font-family: "Supply", monospace !important;
-  font-weight: 400 !important;
+  font-family: var(--font-mono) !important;
+  font-weight: var(--font-weight-regular) !important;
   font-size: 0.74375rem;
   text-transform: uppercase;
   font-stretch: expanded;
   line-height: 92%;
 }
 
-/* Navbar CTA group: 8px gap between buttons + 8px from the right edge.
-   Neutralize Tailwind `space-x-2` (margin-based) so `gap` is the only spacing. */
-#navbar nav ul {
-  gap: 8px !important;
-  margin-inline-end: 8px !important;
+#navbar nav ul > li:not(:last-child) {
+  margin-inline-start: 0 !important;
+  margin-inline-end: var(--space-8) !important;
 }
 
-#navbar nav ul > li {
-  margin: 0 !important;
-}
-
-/* "Book a meeting" — outline */
 #navbar nav li:not(#topbar-cta-button) a {
   height: var(--button-height) !important;
-  padding: 0 14px !important;
+  padding: 0 var(--space-14) !important;
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
@@ -250,16 +314,16 @@ html.dark #navbar-transition {
   background: var(--background) !important;
   border: 1px solid var(--border) !important;
   color: var(--primary) !important;
-  transition: background-color 0.2s ease !important;
+  transition: var(--transition-hover) !important;
 }
 
 #navbar nav li:not(#topbar-cta-button) a:hover {
-  background: var(--surface) !important;
+  background: var(--hover) !important;
   color: var(--primary) !important;
 }
 
 #topbar-cta-button a {
-  padding: 4px 8px !important;
+  padding: var(--space-4) var(--space-8) !important;
   height: var(--button-height) !important;
   display: inline-flex !important;
   align-items: center !important;
@@ -267,14 +331,14 @@ html.dark #navbar-transition {
   line-height: 1 !important;
 }
 
-/* "Get Started" — primary */
 #topbar-cta-button a span.absolute {
   background: var(--alt) !important;
-  transition: background-color 0.2s ease !important;
+  transition: var(--transition-hover) !important;
 }
 
 #topbar-cta-button a:hover span.absolute {
   background: var(--hover-alt) !important;
+  opacity: 1 !important;
 }
 
 #topbar-cta-button a div,
@@ -290,28 +354,11 @@ html.dark #navbar-transition {
   color: var(--primary-foreground) !important;
 }
 
-/* ── Navbar button hover text-shift ─────────────────────────────────────────
-   Ports the website's `.button-text-shift` effect. That component reads the
-   label from `data-hover-label` (`content: attr(...)`), set by JS. Mintlify's
-   navbar HTML is fixed — we can't add data attributes, and CSS `content`
-   cannot read an element's text, so we hardcode each label.
-
-   Mechanism (same as the component): the real text is made transparent so it
-   only holds the button's width, and TWO full-size pseudo layers carry the
-   visible label — `::before` sits in place, `::after` waits one box below. On
-   hover both slide up exactly one box: `::before` exits the top, `::after`
-   lands in place. Both layers cover the same box, so translateY(±100%) always
-   clears the clip cleanly (the earlier bug: translating the small text line by
-   its own height didn't clear the taller button, leaving both labels stacked). */
-
-/* Outline buttons — "Book a meeting" and the mobile-only "Get Started".
-   No icon, so the overlay fills the whole button; only the label differs. */
 #navbar nav li:not(#topbar-cta-button) a {
   position: relative !important;
   overflow: hidden !important;
 }
 
-/* Real text kept for width + accessible name, but hidden. */
 #navbar nav li:not(#topbar-cta-button) a > span {
   color: transparent;
 }
@@ -324,7 +371,8 @@ html.dark #navbar-transition {
   align-items: center;
   justify-content: center;
   color: var(--primary);
-  transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform var(--duration-shift) var(--ease-standard);
+  pointer-events: none;
 }
 
 #navbar nav li:not(#topbar-cta-button) a::before {
@@ -332,18 +380,17 @@ html.dark #navbar-transition {
 }
 
 #navbar nav li:not(#topbar-cta-button) a::after {
-  transform: translateY(100%);
+  transform: translateY(115%);
 }
 
-#navbar nav li:not(#topbar-cta-button) a:hover::before {
-  transform: translateY(-100%);
+#navbar nav li:not(#topbar-cta-button) a:is(:hover, :focus-visible)::before {
+  transform: translateY(-115%);
 }
 
-#navbar nav li:not(#topbar-cta-button) a:hover::after {
+#navbar nav li:not(#topbar-cta-button) a:is(:hover, :focus-visible)::after {
   transform: translateY(0);
 }
 
-/* Per-button labels (CSS `content` can't read the element's text). */
 #navbar nav li.navbar-link a::before,
 #navbar nav li.navbar-link a::after {
   content: "Book a meeting";
@@ -354,15 +401,13 @@ html.dark #navbar-transition {
   content: "Get Started";
 }
 
-/* "Get Started" (primary CTA) keeps its arrow icon, so the swap is scoped to
-   the text `span` (a full-button overlay would sit on top of the arrow — the
-   same reason the React component bails on icon buttons). The span is its own
-   clip box, so the two layers swap within the text's height and the arrow
-   stays put. */
 #topbar-cta-button a div > span {
   position: relative;
   overflow: hidden;
-  color: transparent;
+  height: var(--button-height);
+  margin-block: calc(-1 * var(--space-4));
+  box-sizing: border-box;
+  color: transparent !important;
 }
 
 #topbar-cta-button a div > span::before,
@@ -370,8 +415,13 @@ html.dark #navbar-transition {
   content: "Get Started";
   position: absolute;
   inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
   color: var(--primary-foreground);
-  transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform var(--duration-shift) var(--ease-standard);
+  pointer-events: none;
 }
 
 #topbar-cta-button a div > span::before {
@@ -379,23 +429,100 @@ html.dark #navbar-transition {
 }
 
 #topbar-cta-button a div > span::after {
-  transform: translateY(100%);
+  transform: translateY(115%);
 }
 
-#topbar-cta-button a:hover div > span::before {
-  transform: translateY(-100%);
+#topbar-cta-button a:is(:hover, :focus-visible) div > span::before {
+  transform: translateY(-115%);
 }
 
-#topbar-cta-button a:hover div > span::after {
+#topbar-cta-button a:is(:hover, :focus-visible) div > span::after {
   transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #navbar nav li:not(#topbar-cta-button) a::before,
+  #navbar nav li:not(#topbar-cta-button) a::after,
+  #topbar-cta-button a div > span::before,
+  #topbar-cta-button a div > span::after {
+    transition: none;
+  }
+}
+
+#page-context-menu-button {
+  background: var(--background) !important;
+  border-color: var(--border) !important;
+  color: var(--primary) !important;
+  transition: var(--transition-hover) !important;
+}
+
+#page-context-menu-button:hover {
+  background: var(--hover) !important;
+}
+
+#page-context-menu button[aria-haspopup="menu"] {
+  background: var(--background) !important;
+  border-color: var(--border) !important;
+  color: var(--primary) !important;
+  transition: var(--transition-hover) !important;
+}
+
+#page-context-menu button[aria-haspopup="menu"]:hover {
+  background: var(--hover) !important;
+}
+
+#page-context-menu button[aria-haspopup="menu"] svg {
+  color: var(--primary) !important;
+}
+
+#page-context-menu-button span.grid {
+  position: relative;
+  overflow: hidden;
+}
+
+#page-context-menu-button span.grid > span:not(.invisible),
+#page-context-menu-button span.grid::after {
+  transition: transform var(--duration-shift) var(--ease-standard);
+}
+
+#page-context-menu-button span.grid > span:not(.invisible) {
+  transform: translateY(0);
+}
+
+#page-context-menu-button span.grid::after {
+  content: "Copy page";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateY(115%);
+  pointer-events: none;
+}
+
+#page-context-menu-button:is(:hover, :focus-visible)
+  span.grid
+  > span:not(.invisible) {
+  transform: translateY(-115%);
+}
+
+#page-context-menu-button:is(:hover, :focus-visible) span.grid::after {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #page-context-menu-button span.grid > span:not(.invisible),
+  #page-context-menu-button span.grid::after {
+    transition: none;
+  }
 }
 
 /* CTA — secondary */
 a.font-semibold {
   background: var(--background);
   border: 1px solid var(--primary);
-  font-family: "Supply", monospace;
-  font-weight: 400;
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-regular);
   text-transform: uppercase;
   letter-spacing: 0.02em;
   color: var(--primary);
@@ -425,7 +552,7 @@ html.dark a.font-semibold svg {
   background: var(--primary);
 }
 
-/* Nav items */
+/* ==============================  NAV ITEMS  =============================== */
 
 #navigation-items ul {
   display: flex;
@@ -437,7 +564,7 @@ html.dark a.font-semibold svg {
   display: flex !important;
   align-items: center !important;
   gap: 0 !important;
-  padding: 6px 8px !important;
+  padding: var(--space-6) var(--space-8) !important;
   margin-left: 0 !important;
   margin-bottom: 0 !important;
   border: none !important;
@@ -446,8 +573,8 @@ html.dark a.font-semibold svg {
   color: var(--primary) !important;
   opacity: 0.7;
   transition:
-    opacity 0.2s ease,
-    background-color 0.2s ease;
+    opacity var(--duration-base) var(--ease-standard),
+    background-color var(--duration-base) var(--ease-standard);
 }
 
 #navigation-items a.nav-anchor div,
@@ -460,79 +587,55 @@ html.dark a.font-semibold svg {
 }
 
 #navigation-items a.nav-anchor:hover svg {
-  background-color: rgb(156 163 175) !important;
-}
-
-html.dark #navigation-items a.nav-anchor:hover svg {
-  background-color: rgb(107 114 128) !important;
+  background-color: var(--primary) !important;
 }
 
 #navigation-items a.nav-anchor:hover {
   opacity: 1;
-  background-color: var(--secondary) !important;
+  background-color: var(--nav-tint) !important;
   text-decoration: none !important;
   color: var(--primary) !important;
 }
 
-html.dark #navigation-items a.nav-anchor:hover {
-  background-color: rgba(255, 255, 255, 0.08) !important;
-}
+/* ===============================  SIDEBAR  ================================ */
 
-/* Sidebar */
-
-/* Paint sidebar as canvas */
 div:has(> div > #navigation-items) {
   background-color: var(--background) !important;
 }
 
-/* Sidebar group header (e.g. INTRODUCTION): 500, not 600. */
 .sidebar-group-header {
-  font-weight: 400 !important;
+  font-weight: var(--font-weight-regular) !important;
 }
 
 #sidebar-title {
-  padding: 8px !important;
+  padding: var(--space-8) !important;
 }
 
 /* Nav item states */
 #navigation-items .sidebar-group a,
 #navigation-items .sidebar-group button {
   border-left: 2px solid transparent !important;
-  color: color-mix(in srgb, var(--primary) 60%, transparent) !important;
+  color: var(--primary-muted) !important;
   transition:
-    background-color 0.15s ease,
-    border-color 0.15s ease,
-    color 0.15s ease !important;
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard) !important;
 }
 
-/* Inactive icon = muted */
 #navigation-items .sidebar-group a svg {
-  background-color: color-mix(
-    in srgb,
-    var(--primary) 60%,
-    transparent
-  ) !important;
+  background-color: var(--primary-muted) !important;
 }
 
 /* Hover */
 #navigation-items .sidebar-group a:hover,
 #navigation-items .sidebar-group button:hover {
-  background-color: color-mix(
-    in srgb,
-    var(--primary) 8%,
-    transparent
-  ) !important;
+  background-color: var(--nav-tint) !important;
   color: var(--primary) !important;
 }
 
-/* Active page indicator */
 #navigation-items .sidebar-group a[class*="bg-primary"] {
   border-left-color: var(--primary) !important;
-  background-color: color-mix(
-    in srgb,
-    var(--primary) 8%,
-    transparent
-  ) !important;
+  background-color: var(--nav-tint) !important;
   color: var(--primary) !important;
 }
 
@@ -542,7 +645,6 @@ div:has(> div > #navigation-items) {
   background-color: var(--primary) !important;
 }
 
-/* Remove border from list links */
 ul li a {
   border-bottom: none !important;
 }
@@ -552,7 +654,16 @@ a.link {
   border: none !important;
 }
 
-/* Code */
+.prose :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-weight: var(--font-weight-semibold) !important;
+}
+
+.prose
+  :where(strong):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-weight: var(--font-weight-semibold) !important;
+}
+
+/* =================================  CODE  ================================= */
 
 :not(pre) > code {
   --code-bg: #ececec;
@@ -569,24 +680,29 @@ pre code {
   color: unset !important;
 }
 
-/* Code blocks — blog style */
+@layer utilities {
+  .code-block,
+  .code-block *,
+  .code-group,
+  .code-group * {
+    border-radius: var(--code-block-radius) !important;
+  }
+}
+
 .code-block {
-  --blog-code-bg: #171614;
-  --blog-code-border: rgba(246, 244, 240, 0.22);
-  --blog-code-text: #f4f1ea;
-  --blog-code-muted: rgba(244, 241, 234, 0.62);
-  /* Strip Mintlify chrome */
-  border: 0 !important;
+  border: 1px solid var(--blog-code-border) !important;
   border-radius: 0 !important;
   padding: 0 !important;
-  background: transparent !important;
+  background: var(--blog-code-bg) !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
 }
 
 /* Title header */
 .code-block [data-component-part="code-block-header"] {
   min-height: 2.25rem;
   padding: 0.375rem 0.625rem 0.375rem 1rem;
-  background-color: var(--blog-code-bg) !important;
+  background-color: var(--blog-code-header-bg) !important;
   border-bottom: 1px solid var(--blog-code-border) !important;
   border-radius: 0 !important;
 }
@@ -595,7 +711,52 @@ pre code {
   color: var(--blog-code-muted) !important;
 }
 
-/* Dark surface, sharp corners */
+.code-block {
+  --lang-label: "Code";
+}
+.code-block[language="python"] {
+  --lang-label: "Python";
+}
+.code-block[language="bash"] {
+  --lang-label: "Bash";
+}
+.code-block[language="shell"],
+.code-block[language="shellscript"] {
+  --lang-label: "Shell";
+}
+.code-block[language="r"] {
+  --lang-label: "R";
+}
+.code-block[language="md"],
+.code-block[language="markdown"] {
+  --lang-label: "Markdown";
+}
+.code-block[language="text"],
+.code-block[language="plaintext"],
+.code-block[language="txt"] {
+  --lang-label: "Text";
+}
+
+.code-block [data-component-part="code-block-header-filename"]::before {
+  content: var(--lang-label) " - ";
+}
+
+.code-block:not(:has([data-component-part="code-block-header"]))::before {
+  content: var(--lang-label) " - Example";
+  display: flex;
+  align-items: center;
+  min-height: 2.25rem;
+  padding: 0.375rem 0.625rem 0.375rem 1rem;
+  font-size: 0.875rem;
+  color: var(--blog-code-muted);
+  background-color: var(--blog-code-header-bg);
+  border-bottom: 1px solid var(--blog-code-border);
+}
+
+.code-group .code-block::before {
+  content: none !important;
+}
+
 .code-block [data-component-part="code-block-root"],
 .code-block pre.shiki {
   --shiki-dark-bg: var(--blog-code-bg) !important;
@@ -604,17 +765,13 @@ pre code {
   border-radius: 0 !important;
 }
 
-/* Force dark tokens in light (standalone blocks only; code groups are themed
-   #fff/#000 and keep the native light syntax theme in light mode). */
-html:not(.dark) .code-block:not(.code-group *) .shiki,
-html:not(.dark) .code-block:not(.code-group *) .shiki span {
+html:not(.dark) .code-block .shiki,
+html:not(.dark) .code-block .shiki span {
   color: var(--shiki-dark) !important;
 }
 
-/* Bottom fade → dark surface */
 .code-block [data-fade-overlay] {
-  --fade-color-light: var(--blog-code-bg) !important;
-  --fade-color-dark: var(--blog-code-bg) !important;
+  display: none !important;
 }
 
 /* Copy button */
@@ -631,84 +788,215 @@ html:not(.dark) .code-block:not(.code-group *) .shiki span {
   color: var(--blog-code-text) !important;
 }
 .code-block [data-testid="copy-code-button"]:hover {
-  background-color: rgba(246, 244, 240, 0.08) !important;
+  background-color: var(--code-hover-overlay) !important;
 }
 
-/* Code group (tabbed code blocks) */
+.code-block:not(:has([data-component-part="code-block-header"]))
+  [data-floating-buttons] {
+  top: 0 !important;
+  bottom: auto !important;
+  height: 2.25rem !important;
+  right: 0.625rem !important;
+  align-items: center !important;
+}
 
-/* Themed surface (#fff light / #000 dark), sharp corners — our design.
-   `body` prefix so it out-specifies the global .rounded-2xl utility. */
-body .code-group,
-.code-group [data-component-part="code-block-root"],
-.code-group pre.shiki,
-.code-group .code-block {
+body .code-group {
   border-radius: 0 !important;
-}
-
-.code-group {
   background-color: var(--code-group-bg) !important;
   border: 1px solid var(--code-group-border) !important;
+  padding: var(--space-16) !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  position: relative;
+  isolation: isolate;
 }
 
-/* Code surface = themed; keep native syntax theme per mode (light theme on
-   #fff, dark theme on #000). Plain (unspanned) text uses --primary. */
-.code-group [data-component-part="code-block-root"],
-.code-group pre.shiki {
-  background-color: var(--code-group-bg) !important;
-  --shiki-dark-bg: #000000 !important;
-  color: var(--primary) !important;
-}
-
-/* Filename header + nested block chrome themed */
-.code-group [data-component-part="code-block-header"] {
-  background-color: var(--code-group-bg) !important;
-  border-bottom-color: var(--code-group-border) !important;
+body .code-group::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
+  background-repeat: repeat;
+  background-size: var(--grain-size);
+  filter: grayscale(1) contrast(1.5);
+  opacity: var(--grain-opacity);
 }
 
 .code-group .code-block {
-  background: transparent !important;
-  border: 0 !important;
+  border: 1px solid var(--blog-code-border) !important;
+  margin: 0 !important;
 }
 
-.code-group [data-fade-overlay] {
-  --fade-color-light: #ffffff !important;
-  --fade-color-dark: #000000 !important;
+.code-group [data-component-part="code-group-tab-bar"] + div {
+  margin-top: var(--space-16) !important;
 }
 
-/* Tabs: active = --primary, inactive = --primary-muted */
+@layer utilities {
+  body .code-group [role="tabpanel"] [data-component-part="code-block-root"],
+  body .code-group [role="tabpanel"] pre.shiki {
+    border-radius: 0 !important;
+  }
+
+  body
+    .code-group:has(.code-block)
+    [role="tabpanel"]
+    > [data-component-part="code-block-root"] {
+    height: auto !important;
+  }
+
+  body
+    .code-group:has(.code-block)
+    [role="tabpanel"]
+    > [data-component-part="code-block-root"]
+    > [data-component-part="scroll-area-viewport"] {
+    padding: 0 !important;
+  }
+
+  body
+    .code-group:not(:has(.code-block))
+    [role="tabpanel"]
+    > [data-component-part="code-block-root"]
+    > [data-component-part="scroll-area-viewport"] {
+    overflow-y: auto !important;
+  }
+}
+
 .code-group [role="tab"] {
-  color: var(--primary-muted) !important;
+  color: var(--blog-code-muted) !important;
 }
 
 .code-group [role="tab"][aria-selected="true"] {
-  color: var(--primary) !important;
+  color: var(--blog-code-text) !important;
 }
 
 .code-group [role="tab"] svg {
   background-color: currentColor !important;
 }
 
-/* Active-tab underline indicator = --primary */
 .code-group [role="tab"] [class*="bg-primary"] {
-  background-color: var(--primary) !important;
+  background-color: var(--blog-code-text) !important;
 }
 
-/* Hide the group-level copy button (far right of the tab bar); each block still
-   has its own copy button in its header. */
-.code-group
+.code-group [role="tab"]:hover > div:first-child {
+  background-color: var(--code-tab-hover) !important;
+}
+
+.code-group:has(.code-block)
   > [data-component-part="code-group-tab-bar"]
   [data-testid="copy-code-button"] {
   display: none !important;
 }
 
-/* TOC */
+.code-group:not(:has(.code-block)) [data-component-part="code-block-root"],
+.code-group:not(:has(.code-block)) pre.shiki {
+  background-color: var(--code-group-bg) !important;
+  --shiki-dark-bg: var(--code-group-bg) !important;
+  color: var(--blog-code-text) !important;
+}
+html:not(.dark) .code-group:not(:has(.code-block)) .shiki,
+html:not(.dark) .code-group:not(:has(.code-block)) .shiki span {
+  color: var(--shiki-dark) !important;
+}
 
-/* Table of contents: inactive items use --primary-muted, the active item (and
-   hover) uses --primary. */
+.code-group:not(:has(.code-block))
+  [role="tabpanel"]
+  > [data-component-part="code-block-root"] {
+  position: relative;
+}
+.code-group:not(:has(.code-block))
+  [role="tabpanel"]
+  > [data-component-part="code-block-root"]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
+  background-repeat: repeat;
+  background-size: var(--grain-size);
+  filter: grayscale(1) contrast(1.5);
+  opacity: var(--grain-opacity);
+}
+
+.code-group:not(:has(.code-block))
+  [data-component-part="code-group-tab-bar"]
+  span {
+  color: var(--blog-code-text) !important;
+}
+
+.code-group
+  [data-component-part="code-group-tab-bar"]
+  button[aria-haspopup="menu"]
+  > div {
+  border: 1px solid var(--blog-code-border) !important;
+  border-radius: 0 !important;
+  background-color: transparent !important;
+}
+.code-group
+  [data-component-part="code-group-tab-bar"]
+  button[aria-haspopup="menu"]
+  > div,
+.code-group
+  [data-component-part="code-group-tab-bar"]
+  button[aria-haspopup="menu"]
+  > div
+  * {
+  color: var(--primary-foreground) !important;
+}
+html.dark
+  .code-group
+  [data-component-part="code-group-tab-bar"]
+  button[aria-haspopup="menu"]
+  > div,
+html.dark
+  .code-group
+  [data-component-part="code-group-tab-bar"]
+  button[aria-haspopup="menu"]
+  > div
+  * {
+  color: var(--primary) !important;
+}
+.code-group
+  [data-component-part="code-group-tab-bar"]
+  button[aria-haspopup="menu"]
+  > div:hover {
+  background-color: var(--code-hover-overlay) !important;
+  color: var(--blog-code-text) !important;
+}
+
+.code-group:not(:has(.code-block))
+  > [data-component-part="code-group-tab-bar"]
+  [data-testid="copy-code-button"] {
+  display: flex !important;
+  border: 1px solid var(--blog-code-border) !important;
+  border-radius: 0 !important;
+  color: var(--blog-code-muted) !important;
+}
+.code-group:not(:has(.code-block))
+  > [data-component-part="code-group-tab-bar"]
+  [data-testid="copy-code-button"]:hover {
+  background-color: var(--code-hover-overlay) !important;
+  color: var(--blog-code-text) !important;
+}
+.code-group:not(:has(.code-block))
+  > [data-component-part="code-group-tab-bar"]
+  [data-testid="copy-code-button"]
+  svg {
+  color: inherit !important;
+}
+
+/* ==========================  TABLE OF CONTENTS  =========================== */
+
+#table-of-contents-content {
+  margin-top: var(--space-12);
+}
+
 #table-of-contents-content a,
 .toc a {
   color: var(--primary-muted) !important;
-  transition: color 0.15s ease;
+  transition: color var(--duration-fast) var(--ease-standard);
 }
 
 #table-of-contents-content a:hover,
@@ -719,42 +1007,214 @@ body .code-group,
   color: var(--primary) !important;
 }
 
-/* The "mint" theme doesn't render the vertical rail that other Mintlify themes
-   (e.g. Greptile's) draw next to the TOC, so we build it here: a faint left
-   border on every item, highlighted on the active one — that's the "you are
-   here" indicator. Border lives on the <li> so anchor padding keeps the
-   existing depth indentation. */
-#table-of-contents-content .toc-item {
-  border-left: 1.5px solid color-mix(in srgb, var(--primary) 14%, transparent);
-  padding-left: 0.75rem;
-  transition: border-color 0.15s ease;
+#table-of-contents-content .toc-item > ul {
+  margin-left: 0;
+  padding-left: 0;
 }
 
-#table-of-contents-content .toc-item[data-active="true"] {
+#table-of-contents-content .toc-item[data-depth="0"] > a {
+  border-left: 1.5px solid var(--toc-rail);
+  padding-left: 1rem;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+}
+
+#table-of-contents-content .toc-item:not([data-depth="0"]) {
+  border-left: 1.5px solid var(--toc-rail);
+  padding-left: 1rem;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+}
+
+#table-of-contents-content .toc-item[data-depth="0"][data-active="true"] > a,
+#table-of-contents-content .toc-item[data-active="true"]:not([data-depth="0"]) {
   border-left-color: var(--primary);
 }
 
-/* Subtle weight on the active label so it reads clearly even though --primary
-   is grayscale (mirrors Greptile's text-shadow trick). */
 #table-of-contents-content .toc-item[data-active="true"] > a,
 #table-of-contents-content a[aria-current="location"],
 .toc a[aria-current="location"] {
-  text-shadow: -0.15px 0 0 currentColor, 0.15px 0 0 currentColor;
+  text-shadow:
+    -0.15px 0 0 currentColor,
+    0.15px 0 0 currentColor;
 }
 
-/* Content layout */
+/* ============================  CONTENT LAYOUT  ============================ */
 
 #content-area {
   display: flex;
   flex-direction: column;
-  gap: 80px;
+  gap: var(--spacing-content-area);
+}
+
+#footer {
+  margin-top: var(--spacing-footer-top) !important;
 }
 
 .mdx-content {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-mdx-content);
   margin: 0;
+}
+
+.prose :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: var(--spacing-mdx-content-prose-headers) !important;
+  margin-bottom: 0 !important;
+}
+
+.prose
+  :where(h2):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ):first-child {
+  margin-top: 0 !important;
+}
+
+.prose
+  span
+  + :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: var(--space-20) !important;
+}
+
+.prose :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: var(--spacing-mdx-content-prose-headers-small) !important;
+  margin-bottom: 0 !important;
+}
+
+.prose
+  span
+  + :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: var(--space-20) !important;
+}
+
+.prose
+  :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *))
+  + :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: 0 !important;
+}
+
+.prose :where(h1):not(:where([class~="not-prose"], [class~="not-prose"] *)),
+.prose :where(h4):not(:where([class~="not-prose"], [class~="not-prose"] *)),
+.prose :where(ul):not(:where([class~="not-prose"], [class~="not-prose"] *)),
+.prose :where(p):not(:where([class~="not-prose"], [class~="not-prose"] *)),
+.prose :where(ol):not(:where([class~="not-prose"], [class~="not-prose"] *)),
+.prose :where(img):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+.prose :where(table):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--table-border) !important;
+  background-color: var(--table-bg) !important;
+  font-size: 0.875rem;
+  color: var(--primary);
+}
+
+.prose
+  :where(table th):not(:where([class~="not-prose"], [class~="not-prose"] *)),
+.prose
+  :where(table td):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  padding: 0.875rem 1rem;
+  border-right: 1px solid var(--table-border) !important;
+  border-bottom: 1px solid var(--table-border) !important;
+  text-align: left;
+  vertical-align: middle;
+  font-weight: var(--font-weight-regular);
+  color: var(--primary);
+  background-color: transparent !important;
+}
+
+.prose
+  :where(table th):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  background-color: var(--table-header-bg) !important;
+  font-weight: var(--font-weight-semibold);
+}
+
+.prose
+  :where(table th:last-child):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ),
+.prose
+  :where(table td:last-child):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ) {
+  border-right: 0 !important;
+}
+
+.prose
+  :where(table tbody tr:last-child td):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ) {
+  border-bottom: 0 !important;
+}
+
+.prose
+  :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  position: relative;
+  margin: 0 !important;
+  padding: var(--space-32) !important;
+  background-color: var(--surface);
+  border: none !important;
+  color: var(--primary) !important;
+  font-style: normal !important;
+  font-weight: var(--font-weight-regular) !important;
+  overflow: hidden;
+}
+
+.prose
+  :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *))
+  :where(p):first-of-type::before,
+.prose
+  :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *))
+  :where(p):last-of-type::after {
+  content: "" !important;
+}
+
+.prose
+  :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *))
+  > * {
+  position: relative;
+  z-index: 1;
+}
+
+.prose
+  :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *))
+  :where(p) {
+  line-height: 1.6 !important;
+}
+
+.prose
+  :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *))
+  :where(p)
+  + :where(p) {
+  margin-top: var(--space-16) !important;
+}
+
+[data-component-part="card-content-container"] {
+  padding: 0 !important;
+  padding-block: 0 !important;
+  padding-inline: 0 !important;
+}
+
+.prose :where(li):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: var(--spacing-mdx-content-prose-li) !important;
+  margin-bottom: var(--spacing-mdx-content-prose-li) !important;
+}
+
+.prose
+  :where(li):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ):first-child {
+  margin-top: 0 !important;
+}
+
+.prose
+  :where(li):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ):last-child {
+  margin-bottom: 0 !important;
 }
 
 .mdx-content br {
@@ -767,23 +1227,108 @@ body .code-group,
 }
 
 details.accordion :not(summary) span[data-as="p"] {
-  margin-bottom: 20px !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
 }
 
 .mdx-content hr {
-  margin-top: 20px !important;
-  margin-bottom: 20px !important;
+  margin-top: var(--space-20) !important;
+  margin-bottom: calc(-1 * var(--spacing-mdx-content)) !important;
+}
+
+.prose :where(hr):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  border-color: var(--border) !important;
 }
 
 [role="list"].steps {
-  margin-top: 20px !important;
-  margin-bottom: 20px !important;
+  margin-top: var(--spacing-component-top) !important;
+  margin-bottom: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-list-steps-gap);
+}
+
+[data-rmiz-portal] {
+  margin-block: 0 !important;
+}
+
+img[alt="Open In Colab"] {
+  height: var(--image-link-badge-height) !important;
+  width: auto !important;
+  line-height: 0 !important;
+}
+
+a:has(img[alt="Open In Colab"]) [data-rmiz],
+a:has(img[alt="Open In Colab"]) [data-rmiz-content] {
+  display: inline-flex !important;
+}
+
+a:has(img[alt="Open In Colab"]) [data-rmiz-ghost],
+a:has(img[alt="Open In Colab"]) [data-rmiz-ghost] button {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+span[data-as="p"]:has(img[alt="Open In Colab"]) {
+  line-height: 0 !important;
+}
+
+[role="listitem"].step {
+  padding-bottom: 0px !important;
+}
+
+[data-component-part="accordion-content"] {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: var(--space-20) !important;
+  margin-top: var(--space-20) !important;
+  margin-bottom: var(--space-20) !important;
+  margin-inline: var(--space-20) !important;
+  overflow: visible !important;
+}
+
+[data-component-part="accordion-content"] .steps {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+[data-component-part="frame-caption"] {
+  margin-top: var(--space-20) !important;
+  padding-bottom: 0 !important;
+}
+
+.callout {
+  margin-block: 0 !important;
+}
+
+.accordion-group {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  border-color: var(--border);
+}
+
+[data-component-part="tabs-list"] {
+  margin-bottom: 0 !important;
+}
+
+[data-component-part="tab-content"]:not(.hidden) {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: var(--space-20) !important;
+  margin-top: var(--space-20) !important;
+}
+
+[data-component-part="tab-button"] {
+  margin-top: 0 !important;
+  margin-bottom: -1px !important;
+  padding-top: 0 !important;
+  padding-bottom: var(--space-4) !important;
 }
 
 #header {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 0px;
   position: relative;
 }
 
@@ -791,11 +1336,10 @@ details.accordion :not(summary) span[data-as="p"] {
   max-width: 420px;
 }
 
-/* Desktop header layout */
 @media (min-width: 640px) {
   #header > div > .eyebrow {
     padding-right: 180px;
-    height: 40px;
+    height: var(--spacing-header-description);
     display: flex;
     align-items: center;
   }
@@ -804,7 +1348,7 @@ details.accordion :not(summary) span[data-as="p"] {
     flex-direction: column !important;
     align-items: flex-start !important;
     position: static !important;
-    margin-top: 24px !important;
+    margin-top: 0px !important;
   }
 
   #page-title {
@@ -812,13 +1356,35 @@ details.accordion :not(summary) span[data-as="p"] {
     flex: none !important;
   }
 
-  #header #page-context-menu {
+  #header .mt-2.text-lg {
+    margin-top: var(--spacing-header-description) !important;
+  }
+}
+
+@media (max-width: 991px) {
+  #page-context-menu.ml-auto {
+    display: none !important;
+  }
+
+  #page-context-menu.mt-3 {
+    display: flex !important;
+    margin-top: var(--space-16) !important;
+  }
+}
+
+@media (min-width: 992px) {
+  #page-context-menu.mt-3 {
+    display: none !important;
+  }
+
+  #header #page-context-menu.ml-auto {
+    display: flex !important;
     position: absolute !important;
-    top: 5px !important;
+    top: 0px !important;
     right: 0 !important;
-    margin-left: 0 !important;
+    margin-top: 0 !important;
     align-items: center !important;
-    justify-content: center !important;
+    justify-content: flex-end !important;
   }
 }
 
@@ -828,59 +1394,48 @@ details.accordion :not(summary) span[data-as="p"] {
 
 #content-side-layout a.font-medium {
   color: var(--primary);
-  font-weight: 500;
+  font-weight: var(--font-weight-semibold);
 }
 
-/* Cards */
+/* ================================  CARDS  ================================= */
 
-/* Grid: border collapse */
-.card-group {
-  gap: 0 !important;
-  border-top: 1px solid var(--card-border);
-  border-left: 1px solid var(--card-border);
-}
-
-/* Card */
 a.card,
 div.card {
   margin: 0 !important;
   padding: 0 !important;
   background: var(--card-bg) !important;
-  border: none !important;
-  border-right: 1px solid var(--card-border) !important;
-  border-bottom: 1px solid var(--card-border) !important;
+  border: 1px solid var(--card-border) !important;
   border-radius: 0 !important;
   box-shadow: none !important;
   outline: none !important;
   --tw-ring-offset-shadow: 0 0 0 0 transparent !important;
   --tw-ring-shadow: 0 0 0 0 transparent !important;
   --tw-ring-color: transparent !important;
-  transition: background-color 0.2s ease;
+  transition: var(--transition-hover);
+}
+
+.card-group {
+  gap: 0 !important;
+  border-top: 1px solid var(--card-border);
+  border-left: 1px solid var(--card-border);
+}
+
+.card-group a.card,
+.card-group div.card {
+  border-top: none !important;
+  border-left: none !important;
 }
 
 a.card:hover,
 div.card:hover,
 html.dark a.card:hover,
 html.dark div.card:hover {
-  background: var(--card-bg-hover) !important;
-  border: none !important;
-  border-right: 1px solid var(--card-border) !important;
-  border-bottom: 1px solid var(--card-border) !important;
+  background: var(--hover) !important;
   box-shadow: none !important;
   outline: none !important;
   --tw-ring-offset-shadow: 0 0 0 0 transparent !important;
   --tw-ring-shadow: 0 0 0 0 transparent !important;
   --tw-ring-color: transparent !important;
-}
-
-/* Linked-card hover border */
-@layer utilities {
-  div.card[role="link"]:hover,
-  a.card[href]:hover {
-    border-right-color: var(--primary) !important;
-    border-bottom-color: var(--primary) !important;
-    box-shadow: inset 1px 1px 0 0 var(--primary) !important;
-  }
 }
 
 html.dark a.card svg,
@@ -890,98 +1445,169 @@ html.dark div.card svg {
 
 /* Content container */
 [data-component-part="card-content-container"] {
-  padding: 40px 30px !important;
+  padding: var(--space-32) var(--space-32) !important;
   display: flex !important;
   flex-direction: column !important;
-  gap: 30px !important;
+  gap: var(--space-24) !important;
 }
 
 /* Icon */
 [data-component-part="card-icon"] {
-  width: 24px !important;
-  height: 24px !important;
+  width: var(--space-24) !important;
+  height: var(--space-24) !important;
   flex-shrink: 0;
 }
 
 [data-component-part="card-icon"] svg {
-  width: 24px !important;
-  height: 24px !important;
+  width: var(--space-24) !important;
+  height: var(--space-24) !important;
   background-color: var(--primary) !important;
 }
 
-/* Title+desc wrapper; skip table */
 [data-component-part="card-content-container"] .w-full:not(table) {
   display: flex !important;
   flex-direction: column !important;
-  gap: 14px !important;
+  gap: var(--space-16) !important;
 }
 
 /* Title */
 [data-component-part="card-title"] {
   font-size: 26px !important;
   font-style: normal !important;
-  font-weight: 400 !important;
+  font-weight: var(--font-weight-regular) !important;
   line-height: 100% !important;
-  font-family: "NeueMontreal", sans-serif !important;
+  font-family: var(--font-sans) !important;
   color: var(--primary) !important;
   margin: 0 !important;
+}
+
+[data-component-part="card-title"]:empty {
+  display: none !important;
 }
 
 /* Description */
 [data-component-part="card-content"] {
   font-size: 16px !important;
   font-style: normal !important;
-  font-weight: 400 !important;
+  font-weight: var(--font-weight-regular) !important;
   line-height: 24px !important;
   color: var(--primary) !important;
   margin: 0 !important;
   opacity: 0.7;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
 }
 
-/* Accordion */
+[data-component-part="card-content"]:empty {
+  display: none !important;
+}
+
+/* ==============================  ACCORDION  =============================== */
 
 details.accordion,
 details.accordion summary {
   border-radius: 0 !important;
 }
 
-/* Accordion surface: #fff (light) / #000 (dark). Needs html:not(.dark)/html.dark
-   to out-specify the global `.bg-background-light` override, which is (0,2,1). */
+details.accordion {
+  margin-bottom: 0 !important;
+}
+
 html:not(.dark) details.accordion,
 html.dark details.accordion {
   background-color: var(--accordion-bg) !important;
 }
 
 details.accordion summary:hover {
-  background-color: var(--secondary) !important;
+  background-color: var(--hover) !important;
 }
 
-html.dark details.accordion summary:hover {
-  background-color: rgba(255, 255, 255, 0.08) !important;
+[data-component-part="accordion-button"] {
+  border-bottom: 1px solid transparent;
 }
 
-/* Steps */
+[data-component-part="accordion-button"][aria-expanded="true"] {
+  border-bottom-color: var(--border);
+}
 
-/* Step badge: inverted tokens */
+details.accordion {
+  border-color: var(--border) !important;
+}
+
+[data-component-part="tab-content"] > details.accordion + details.accordion {
+  margin-top: calc(-1 * var(--space-20)) !important;
+  border-top: none !important;
+}
+
+details.expandable,
+details.expandable summary,
+details.expandable .expandable-content {
+  border-radius: 0 !important;
+}
+
+html:not(.dark) details.expandable,
+html.dark details.expandable {
+  background-color: var(--accordion-bg) !important;
+  border-color: var(--border) !important;
+}
+
+details.expandable > summary {
+  color: var(--primary-muted) !important;
+}
+
+details.expandable > summary:hover {
+  background-color: var(--hover) !important;
+  color: var(--primary) !important;
+}
+
+details.expandable > summary svg[data-component-part="icon-svg"] {
+  background-color: var(--primary-muted) !important;
+}
+
+details.expandable .expandable-content {
+  border-top-color: var(--border) !important;
+}
+
+details.expandable .array-param-field,
+details.expandable .primitive-param-field {
+  border-color: var(--border) !important;
+}
+
+/* ================================  STEPS  ================================= */
+
 [data-component-part="step-number"] > div {
   background-color: var(--primary) !important;
   color: var(--primary-foreground) !important;
 }
 
-/* Step icon/number sits on the --primary badge, so it must use the foreground
-   token — otherwise the icon (bg-gray-900) is dark-on-dark and invisible
-   (e.g. steps inside an accordion). */
 [data-component-part="step-number"] > div svg {
   background-color: var(--primary-foreground) !important;
 }
 
-/* Tables — blog parity */
+:has(> [data-component-part="step-title"]),
+[data-component-part="step-content"] {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: var(--space-20) !important;
+}
 
-/* Wrapper = bordered surface */
+[data-component-part="step-title"] {
+  margin: 0 !important;
+}
+
+[data-component-part="step-line"] {
+  top: 2.75rem !important;
+  bottom: auto !important;
+  height: 100% !important;
+}
+
+/* ================================  TABLES  ================================ */
+
 [data-table-wrapper] {
   width: 100% !important;
   max-width: 100% !important;
-  margin: 1.5rem 0 !important;
+  margin: 0rem 0 !important;
   padding: 0 !important;
   border: 1px solid var(--table-border);
   background-color: var(--table-bg);
@@ -991,7 +1617,6 @@ html.dark details.accordion summary:hover {
   padding: 0 !important;
 }
 
-/* Transparent, collapse */
 [data-table-wrapper] table {
   margin: 0 !important;
   border: 0 !important;
@@ -1001,7 +1626,6 @@ html.dark details.accordion summary:hover {
   color: var(--primary);
 }
 
-/* Header bg on cells only */
 [data-table-wrapper] table thead,
 [data-table-wrapper] table tbody,
 [data-table-wrapper] table tr {
@@ -1016,7 +1640,7 @@ html.dark details.accordion summary:hover {
   text-align: left;
   vertical-align: middle;
   font-size: 0.875rem;
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   color: var(--primary);
   background-color: transparent !important;
 }
@@ -1024,10 +1648,9 @@ html.dark details.accordion summary:hover {
 [data-table-wrapper] table thead th,
 [data-table-wrapper] table th {
   background-color: var(--table-header-bg) !important;
-  font-weight: 500;
+  font-weight: var(--font-weight-semibold);
 }
 
-/* Dividers between cells */
 [data-table-wrapper] table th:last-child,
 [data-table-wrapper] table td:last-child {
   border-right: 0 !important;
@@ -1037,13 +1660,12 @@ html.dark details.accordion summary:hover {
   border-bottom: 0 !important;
 }
 
-/* First column centered */
 [data-table-wrapper] table th:first-child,
 [data-table-wrapper] table td:first-child {
   text-align: center;
 }
 
-/* Frame */
+/* ================================  FRAME  ================================= */
 
 /* Strip <Frame> chrome */
 .frame {
@@ -1061,9 +1683,8 @@ html.dark details.accordion summary:hover {
   border-radius: 0 !important;
 }
 
-/* Banner */
+/* ================================  BANNER  ================================ */
 
-/* Banner bg via docs.json */
 #banner {
   border-bottom: 1px solid rgb(var(--gray-300) / 0.06) !important;
   height: auto !important;
@@ -1072,12 +1693,11 @@ html.dark details.accordion summary:hover {
 
 @media (max-width: 767px) {
   #banner {
-    padding-top: 4px !important;
-    padding-bottom: 4px !important;
+    padding-top: var(--space-4) !important;
+    padding-bottom: var(--space-4) !important;
   }
 }
 
-/* Banner text = --primary */
 @layer utilities {
   #banner,
   #banner * {
@@ -1093,8 +1713,8 @@ html.dark details.accordion summary:hover {
 
 #banner p,
 #banner p a {
-  font-family: "Supply", monospace !important;
-  font-weight: 400 !important;
+  font-family: var(--font-mono) !important;
+  font-weight: var(--font-weight-regular) !important;
   font-size: 12px !important;
   text-transform: uppercase !important;
   font-stretch: expanded !important;
@@ -1111,26 +1731,26 @@ html.dark details.accordion summary:hover {
   color: var(--primary) !important;
 }
 
-/* Pagination */
+/* ==============================  PAGINATION  ============================== */
 
 #pagination {
-  font-family: "NeueMontreal", sans-serif !important;
+  font-family: var(--font-sans) !important;
   font-size: 30px !important;
-  font-weight: 400 !important;
+  font-weight: var(--font-weight-regular) !important;
   line-height: 100% !important;
   color: var(--primary) !important;
 }
 
 #pagination a span {
   font-size: 20px !important;
-  font-weight: 400 !important;
+  font-weight: var(--font-weight-regular) !important;
   line-height: 120% !important;
   color: var(--primary) !important;
 }
 
 #pagination svg {
-  height: 10px !important;
-  width: 10px !important;
+  height: var(--space-10) !important;
+  width: var(--space-10) !important;
   stroke: var(--primary) !important;
 }
 
@@ -1144,7 +1764,7 @@ html.dark details.accordion summary:hover {
 
 #pagination {
   flex-wrap: wrap !important;
-  gap: 20px !important;
+  gap: var(--space-20) !important;
   align-items: start !important;
   justify-content: space-between !important;
 }
@@ -1158,13 +1778,13 @@ html.dark details.accordion summary:hover {
   text-decoration: underline;
 }
 
-/* Feedback toolbar */
+/* ===========================  FEEDBACK TOOLBAR  =========================== */
 
 .feedback-toolbar p {
   color: var(--primary) !important;
-  font-family: "NeueMontreal", sans-serif !important;
+  font-family: var(--font-sans) !important;
   font-size: 12px !important;
-  font-weight: 400 !important;
+  font-weight: var(--font-weight-regular) !important;
   line-height: 16px !important;
 }
 
@@ -1172,7 +1792,7 @@ html.dark details.accordion summary:hover {
 .feedback-toolbar a {
   background: var(--feedback-btn-bg) !important;
   color: var(--feedback-btn-color) !important;
-  padding: 2px 6px !important;
+  padding: var(--space-2) var(--space-6) !important;
   border-radius: var(--radius) !important;
   border: none !important;
 }
@@ -1181,8 +1801,8 @@ html.dark details.accordion summary:hover {
 .feedback-toolbar button *,
 .feedback-toolbar a,
 .feedback-toolbar a * {
-  font-family: "Supply", monospace !important;
-  font-weight: 400 !important;
+  font-family: var(--font-mono) !important;
+  font-weight: var(--font-weight-regular) !important;
   font-size: 10px !important;
   text-transform: uppercase !important;
   line-height: 22px !important;
@@ -1193,8 +1813,6 @@ html.dark details.accordion summary:hover {
 .feedback-toolbar a svg {
   display: none !important;
 }
-
-/* Page context + dropdown */
 
 [role="menu"][data-orientation="vertical"] {
   background-color: var(--dropdown-bg) !important;
@@ -1211,17 +1829,17 @@ html.dark details.accordion summary:hover {
   box-shadow: none !important;
 }
 
-html.dark [role="menu"][data-orientation="vertical"] [role="menuitem"]:hover {
-  background-color: rgba(0, 0, 0, 0.08) !important;
+[role="menu"][data-orientation="vertical"] [role="menuitem"]:hover {
+  background-color: var(--dropdown-hover) !important;
 }
 
 #page-context-menu-button,
 #page-context-menu-button + button {
   border-radius: 0 !important;
-  background-color: var(--secondary) !important;
-  color: var(--secondary-foreground) !important;
-  font-family: "Supply", monospace !important;
-  font-weight: 400 !important;
+  background-color: var(--background) !important;
+  color: var(--primary) !important;
+  font-family: var(--font-mono) !important;
+  font-weight: var(--font-weight-regular) !important;
   font-size: 12px !important;
   text-transform: uppercase !important;
   font-stretch: expanded !important;
@@ -1233,20 +1851,20 @@ html.dark [role="menu"][data-orientation="vertical"] [role="menuitem"]:hover {
 
 #page-context-menu-button *,
 #page-context-menu-button + button * {
-  font-family: "Supply", monospace !important;
+  font-family: var(--font-mono) !important;
   font-size: 12px !important;
   text-transform: uppercase !important;
   font-stretch: expanded !important;
 }
 
-/* Tabs */
+/* =================================  TABS  ================================= */
 
 [data-component-part="tab-button"][data-active="true"] svg {
   color: var(--primary) !important;
   background-color: var(--primary) !important;
 }
 
-/* Chat assistant */
+/* ============================  CHAT ASSISTANT  ============================ */
 
 #content-area > div:has(.chat-assistant-floating-input) {
   margin-top: -80px !important;
@@ -1257,7 +1875,7 @@ html.dark [role="menu"][data-orientation="vertical"] [role="menuitem"]:hover {
   background-color: transparent !important;
 }
 
-/* Utilities */
+/* ==============================  UTILITIES  =============================== */
 
 a {
   border-radius: var(--radius) !important;
@@ -1280,14 +1898,6 @@ a {
   border-radius: calc(var(--radius) + 0.125rem) !important;
 }
 
-/* Mobile sidebar & iOS safe areas */
-
-/* Mintlify paints a full-viewport fixed <span id="background-color"> using its
-   built-in white background token (bg-background-light). On iOS 26 Safari the
-   status-bar/toolbar tint is sampled from a fixed element's background-color,
-   so this white layer is what makes the bar show white / look transparent with
-   content bleeding under the notch. Repaint it (and the token utilities) with
-   our canvas so every candidate Safari can sample is --background. */
 #background-color,
 .bg-background-light,
 html:not(.dark) .bg-background-light {
@@ -1300,8 +1910,6 @@ html.dark .bg-background-dark,
   background-color: var(--background) !important;
 }
 
-/* Paint the mobile sidebar scroll container as canvas (was white).
-   Scoped to the sidebar so code-block scroll areas keep their own bg. */
 #sidebar,
 #sidebar-content,
 #sidebar [data-component-part^="scroll-area"],
@@ -1312,7 +1920,6 @@ html.dark .bg-background-dark,
   background-color: var(--background) !important;
 }
 
-/* Keep the scrollbar thumb visible over the canvas */
 #sidebar [data-component-part="scroll-area-scrollbar"],
 #sidebar-content [data-component-part="scroll-area-scrollbar"],
 [data-component-part="scroll-area"]:has(#navigation-items)
@@ -1320,16 +1927,12 @@ html.dark .bg-background-dark,
   background-color: transparent !important;
 }
 
-/* Mobile navbar: opaque canvas (like the site), matching how the working
-   default Mintlify docs rely on solid top layers. */
 @media (max-width: 1023px) {
   #navbar,
   #navbar-transition {
     background-color: var(--background) !important;
   }
 }
-
-/* Film grain (nixtla.io noise) */
 
 :root {
   --grain-opacity: 0.08;
@@ -1338,18 +1941,10 @@ html.dark .bg-background-dark,
 
 body::after {
   content: "";
-  /* Fixed so the grain stays static while content scrolls (no "chasing" — that
-     was an `absolute`-only artifact), but BELOW the chrome (navbar z-30, sticky
-     bars z-20) and above content. This keeps the opaque navbar as the top layer
-     at the notch, so iOS 26 Safari samples IT (canvas) for the status bar tint
-     instead of this near-transparent grain — which is what made content bleed
-     through. The grain therefore only overlays the reading area, never the
-     navbar/breadcrumb chrome. */
   position: fixed;
   inset: 0;
   z-index: 10;
   pointer-events: none;
-  /* both roots: / and /docs */
   background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
   background-repeat: repeat;
   background-size: var(--grain-size);
@@ -1357,14 +1952,12 @@ body::after {
   opacity: var(--grain-opacity);
 }
 
-/* Reusable grain layer for a specific block.
-   Unlike the full-viewport body::after, this is a grain overlay SCOPED to a
-   single element (absolute, inset:0). Because it lives inside its block and is
-   not a separate fixed full-viewport layer, it never becomes the element iOS 26
-   samples for the status-bar tint. Add `grain-layer` to any block, or use the
-   selectors below. Applied to #navbar, which on mobile also contains the
-   breadcrumb/hamburger bar — so both get grain in one shot. */
 .grain-layer {
+  position: relative;
+}
+
+/* Search button needs position:relative so its grain ::after anchors to it. */
+#search-bar-entry {
   position: relative;
 }
 
@@ -1372,7 +1965,11 @@ body::after {
 #navbar::after,
 #banner::after,
 #sidebar::after,
-#mobile-nav::after {
+#mobile-nav::after,
+#search-bar-entry::after,
+[data-radix-menu-content]::after,
+[data-component-part="theme-preference-menu-content"]::after,
+[role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -1385,20 +1982,25 @@ body::after {
   opacity: var(--grain-opacity);
 }
 
-/* The desktop sidebar's inner content (#sidebar-content) is z-10, so its grain
-   must sit above that to be visible. */
 #sidebar::after {
   z-index: 11;
 }
 
-/* Opt out for high contrast */
 @media (prefers-contrast: more) {
   body::after,
   .grain-layer::after,
   #navbar::after,
   #banner::after,
   #sidebar::after,
-  #mobile-nav::after {
+  #mobile-nav::after,
+  #search-bar-entry::after,
+  [data-radix-menu-content]::after,
+  [data-component-part="theme-preference-menu-content"]::after,
+  [role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {
     display: none;
   }
+}
+
+#api-playground-2-operation-page :where(.mt-6.space-y-4) > * + * {
+  margin-top: 0px !important;
 }

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -45,7 +45,7 @@
 
   --code-block-radius: 0;
 
-  --page-title-max-width: 35rem;
+  --page-title-max-width: 34rem;
 
   --image-link-badge-height: 28px;
 
@@ -97,6 +97,9 @@
   --duration-fast: 0.15s;
   --duration-base: 0.2s;
   --duration-shift: 220ms;
+  --shift-distance: 115%; /* text/icon hover-shift travel */
+  --duration-slow: 0.4s;
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --transition-hover: background-color var(--duration-base) var(--ease-standard);
 
   /* FONTS */
@@ -389,11 +392,11 @@ html.dark #navbar-transition {
 }
 
 #navbar nav li:not(#topbar-cta-button) a::after {
-  transform: translateY(115%);
+  transform: translateY(var(--shift-distance));
 }
 
 #navbar nav li:not(#topbar-cta-button) a:is(:hover, :focus-visible)::before {
-  transform: translateY(-115%);
+  transform: translateY(calc(-1 * var(--shift-distance)));
 }
 
 #navbar nav li:not(#topbar-cta-button) a:is(:hover, :focus-visible)::after {
@@ -438,14 +441,210 @@ html.dark #navbar-transition {
 }
 
 #topbar-cta-button a div > span::after {
-  transform: translateY(115%);
+  transform: translateY(var(--shift-distance));
 }
 
 #topbar-cta-button a:is(:hover, :focus-visible) div > span::before {
-  transform: translateY(-115%);
+  transform: translateY(calc(-1 * var(--shift-distance)));
 }
 
 #topbar-cta-button a:is(:hover, :focus-visible) div > span::after {
+  transform: translateY(0);
+}
+
+/* Get Started arrow: the SAME reversible two-layer shift as the label. The inline
+   arrow can't be duplicated via content, so it's reproduced as a mask on the two
+   free pseudos of the content div; the real svg is hidden but keeps its width. */
+#topbar-cta-button a div {
+  position: relative;
+  overflow: hidden;
+}
+
+#topbar-cta-button a div > svg {
+  visibility: hidden;
+}
+
+#topbar-cta-button a div::before,
+#topbar-cta-button a div::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 0.75rem;
+  background-color: var(--primary-foreground);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25'/%3E%3C/svg%3E")
+    center / 0.75rem no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25'/%3E%3C/svg%3E")
+    center / 0.75rem no-repeat;
+  transition: transform var(--duration-shift) var(--ease-standard);
+  pointer-events: none;
+}
+
+#topbar-cta-button a div::before {
+  transform: translateY(0);
+}
+
+#topbar-cta-button a div::after {
+  transform: translateY(var(--shift-distance));
+}
+
+#topbar-cta-button a:is(:hover, :focus-visible) div::before {
+  transform: translateY(calc(-1 * var(--shift-distance)));
+}
+
+#topbar-cta-button a:is(:hover, :focus-visible) div::after {
+  transform: translateY(0);
+}
+
+/* ---- Icon hover swap. Same technique + same --duration-shift as the text-shift
+   so text and icon move as one piece. Real icon hidden; two masked pseudo layers
+   (or real-icon-exit + one masked pseudo where a pseudo is taken by grain). ---- */
+
+/* Copy-page "More actions" chevron (icon-only; rotation baked into the mask so
+   the swap is vertical). */
+#page-context-menu button[aria-haspopup="menu"] {
+  position: relative;
+}
+#page-context-menu button[aria-haspopup="menu"] > svg {
+  visibility: hidden;
+}
+#page-context-menu button[aria-haspopup="menu"]::before,
+#page-context-menu button[aria-haspopup="menu"]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25' transform='rotate(90 9 9)'/%3E%3C/svg%3E")
+    center / 0.75rem no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25' transform='rotate(90 9 9)'/%3E%3C/svg%3E")
+    center / 0.75rem no-repeat;
+  transition: transform var(--duration-shift) var(--ease-standard);
+  pointer-events: none;
+}
+#page-context-menu button[aria-haspopup="menu"]::before {
+  transform: translateY(0);
+}
+#page-context-menu button[aria-haspopup="menu"]::after {
+  transform: translateY(150%);
+}
+#page-context-menu button[aria-haspopup="menu"]:hover::before {
+  transform: translateY(-150%);
+}
+#page-context-menu button[aria-haspopup="menu"]:hover::after {
+  transform: translateY(0);
+}
+
+/* Copy-page button copy icon (icon+text; the label shifts via span.grid). */
+#page-context-menu-button {
+  overflow: hidden;
+}
+#page-context-menu-button div {
+  position: relative;
+}
+#page-context-menu-button div > svg {
+  visibility: hidden;
+}
+#page-context-menu-button div::before,
+#page-context-menu-button div::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 1rem;
+  height: 1rem;
+  margin-top: -0.5rem;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.25 5.25H7.25C6.14543 5.25 5.25 6.14543 5.25 7.25V14.25C5.25 15.3546 6.14543 16.25 7.25 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V7.25C16.25 6.14543 15.3546 5.25 14.25 5.25Z'/%3E%3Cpath d='M2.80103 11.998L1.77203 5.07397C1.61003 3.98097 2.36403 2.96397 3.45603 2.80197L10.38 1.77297C11.313 1.63397 12.19 2.16297 12.528 3.00097'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.25 5.25H7.25C6.14543 5.25 5.25 6.14543 5.25 7.25V14.25C5.25 15.3546 6.14543 16.25 7.25 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V7.25C16.25 6.14543 15.3546 5.25 14.25 5.25Z'/%3E%3Cpath d='M2.80103 11.998L1.77203 5.07397C1.61003 3.98097 2.36403 2.96397 3.45603 2.80197L10.38 1.77297C11.313 1.63397 12.19 2.16297 12.528 3.00097'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  transition: transform var(--duration-shift) var(--ease-standard);
+  pointer-events: none;
+}
+#page-context-menu-button div::before {
+  transform: translateY(0);
+}
+#page-context-menu-button div::after {
+  transform: translateY(150%);
+}
+#page-context-menu-button:hover div::before {
+  transform: translateY(-150%);
+}
+#page-context-menu-button:hover div::after {
+  transform: translateY(0);
+}
+
+/* Theme toggle (icon-only, 3 dynamic icons): real icon exits, matching masked
+   copy enters. position (not display) keeps the component's display:none hiding
+   of inactive icons; clipped by the button's overflow-hidden. */
+#theme-preference-menu-trigger {
+  position: relative;
+}
+#theme-preference-menu-trigger span[data-theme-preference-icon] > svg {
+  transition: transform var(--duration-shift) var(--ease-standard);
+}
+#theme-preference-menu-trigger:hover span[data-theme-preference-icon] > svg {
+  transform: translateY(-150%);
+}
+#theme-preference-menu-trigger span[data-theme-preference-icon]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: currentColor;
+  transition: transform var(--duration-shift) var(--ease-standard);
+  transform: translateY(150%);
+  pointer-events: none;
+}
+#theme-preference-menu-trigger:hover span[data-theme-preference-icon]::after {
+  transform: translateY(0);
+}
+#theme-preference-menu-trigger
+  span[data-theme-preference-icon="system"]::after {
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4.5 15.5L9 14.5L13.5 15.5'/%3E%3Cpath d='M9 11.75V14.5'/%3E%3Cpath d='M14.25 2.75H3.75C2.64543 2.75 1.75 3.64543 1.75 4.75V9.75C1.75 10.8546 2.64543 11.75 3.75 11.75H14.25C15.3546 11.75 16.25 10.8546 16.25 9.75V4.75C16.25 3.64543 15.3546 2.75 14.25 2.75Z'/%3E%3C/svg%3E")
+    center / 1rem no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4.5 15.5L9 14.5L13.5 15.5'/%3E%3Cpath d='M9 11.75V14.5'/%3E%3Cpath d='M14.25 2.75H3.75C2.64543 2.75 1.75 3.64543 1.75 4.75V9.75C1.75 10.8546 2.64543 11.75 3.75 11.75H14.25C15.3546 11.75 16.25 10.8546 16.25 9.75V4.75C16.25 3.64543 15.3546 2.75 14.25 2.75Z'/%3E%3C/svg%3E")
+    center / 1rem no-repeat;
+}
+#theme-preference-menu-trigger span[data-theme-preference-icon="light"]::after {
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 1.25V2.25'/%3E%3Cpath d='M14.48 3.52002L13.773 4.22702'/%3E%3Cpath d='M16.75 9H15.75'/%3E%3Cpath d='M14.48 14.4799L13.773 13.7729'/%3E%3Cpath d='M9 16.75V15.75'/%3E%3Cpath d='M3.52 14.4799L4.227 13.7729'/%3E%3Cpath d='M1.25 9H2.25'/%3E%3Cpath d='M3.52 3.52002L4.227 4.22702'/%3E%3Cpath d='M9 13.25C11.3472 13.25 13.25 11.3472 13.25 9C13.25 6.65279 11.3472 4.75 9 4.75C6.65279 4.75 4.75 6.65279 4.75 9C4.75 11.3472 6.65279 13.25 9 13.25Z'/%3E%3C/svg%3E")
+    center / 1rem no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 1.25V2.25'/%3E%3Cpath d='M14.48 3.52002L13.773 4.22702'/%3E%3Cpath d='M16.75 9H15.75'/%3E%3Cpath d='M14.48 14.4799L13.773 13.7729'/%3E%3Cpath d='M9 16.75V15.75'/%3E%3Cpath d='M3.52 14.4799L4.227 13.7729'/%3E%3Cpath d='M1.25 9H2.25'/%3E%3Cpath d='M3.52 3.52002L4.227 4.22702'/%3E%3Cpath d='M9 13.25C11.3472 13.25 13.25 11.3472 13.25 9C13.25 6.65279 11.3472 4.75 9 4.75C6.65279 4.75 4.75 6.65279 4.75 9C4.75 11.3472 6.65279 13.25 9 13.25Z'/%3E%3C/svg%3E")
+    center / 1rem no-repeat;
+}
+#theme-preference-menu-trigger span[data-theme-preference-icon="dark"]::after {
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M13 11.75C9.548 11.75 6.75 8.95201 6.75 5.50001C6.75 4.14801 7.183 2.90101 7.912 1.87801C4.548 2.50601 2 5.45301 2 9.00001C2 13.004 5.246 16.25 9.25 16.25C12.622 16.25 15.448 13.944 16.259 10.826C15.309 11.409 14.196 11.75 13 11.75Z'/%3E%3C/svg%3E")
+    center / 1rem no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M13 11.75C9.548 11.75 6.75 8.95201 6.75 5.50001C6.75 4.14801 7.183 2.90101 7.912 1.87801C4.548 2.50601 2 5.45301 2 9.00001C2 13.004 5.246 16.25 9.25 16.25C12.622 16.25 15.448 13.944 16.259 10.826C15.309 11.409 14.196 11.75 13 11.75Z'/%3E%3C/svg%3E")
+    center / 1rem no-repeat;
+}
+
+/* Assistant sparkle (icon+text; label shifts via its span). ::after is the grain,
+   so the incoming copy uses ::before while the real sparkle exits. */
+#assistant-entry > svg {
+  transition: transform var(--duration-shift) var(--ease-standard);
+}
+#assistant-entry:hover > svg {
+  transform: translateY(-150%);
+}
+#assistant-entry::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  width: 1rem;
+  height: 1rem;
+  margin-top: -0.5rem;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath d='M5.65799 2.99L4.39499 2.569L3.97399 1.306C3.83699 0.898 3.16199 0.898 3.02499 1.306L2.60399 2.569L1.34099 2.99C1.13699 3.058 0.998993 3.249 0.998993 3.464C0.998993 3.679 1.13699 3.87 1.34099 3.938L2.60399 4.359L3.02499 5.622C3.09299 5.826 3.28499 5.964 3.49999 5.964C3.71499 5.964 3.90599 5.826 3.97499 5.622L4.39599 4.359L5.65899 3.938C5.86299 3.87 6.00099 3.679 6.00099 3.464C6.00099 3.249 5.86199 3.058 5.65799 2.99Z' fill='%23000'/%3E%3Cpath d='M9.5 2.75L11.412 7.587L16.25 9.5L11.412 11.413L9.5 16.25L7.587 11.413L2.75 9.5L7.587 7.587L9.5 2.75Z' fill='none' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath d='M5.65799 2.99L4.39499 2.569L3.97399 1.306C3.83699 0.898 3.16199 0.898 3.02499 1.306L2.60399 2.569L1.34099 2.99C1.13699 3.058 0.998993 3.249 0.998993 3.464C0.998993 3.679 1.13699 3.87 1.34099 3.938L2.60399 4.359L3.02499 5.622C3.09299 5.826 3.28499 5.964 3.49999 5.964C3.71499 5.964 3.90599 5.826 3.97499 5.622L4.39599 4.359L5.65899 3.938C5.86299 3.87 6.00099 3.679 6.00099 3.464C6.00099 3.249 5.86199 3.058 5.65799 2.99Z' fill='%23000'/%3E%3Cpath d='M9.5 2.75L11.412 7.587L16.25 9.5L11.412 11.413L9.5 16.25L7.587 11.413L2.75 9.5L7.587 7.587L9.5 2.75Z' fill='none' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  transition: transform var(--duration-shift) var(--ease-standard);
+  transform: translateY(150%);
+  pointer-events: none;
+}
+#assistant-entry:hover::before {
   transform: translateY(0);
 }
 
@@ -496,11 +695,11 @@ html.dark #navbar-transition {
 }
 
 #assistant-entry span::after {
-  transform: translateY(115%);
+  transform: translateY(var(--shift-distance));
 }
 
 #assistant-entry:is(:hover, :focus-visible) span::before {
-  transform: translateY(-115%);
+  transform: translateY(calc(-1 * var(--shift-distance)));
 }
 
 #assistant-entry:is(:hover, :focus-visible) span::after {
@@ -565,14 +764,14 @@ html.dark #navbar-transition {
   display: flex;
   align-items: center;
   justify-content: center;
-  transform: translateY(115%);
+  transform: translateY(var(--shift-distance));
   pointer-events: none;
 }
 
 #page-context-menu-button:is(:hover, :focus-visible)
   span.grid
   > span:not(.invisible) {
-  transform: translateY(-115%);
+  transform: translateY(calc(-1 * var(--shift-distance)));
 }
 
 #page-context-menu-button:is(:hover, :focus-visible) span.grid::after {
@@ -1828,7 +2027,7 @@ details.expandable .primitive-param-field {
 }
 
 #pagination a {
-  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity var(--duration-slow) var(--ease-in-out);
 }
 
 #pagination {
@@ -1938,6 +2137,12 @@ details.expandable .primitive-param-field {
 #content-area > div:has(.chat-assistant-floating-input) {
   margin-top: -80px !important;
   margin-bottom: -80px !important;
+}
+
+/* Desktop assistant panel: solid #fff / #000 surface (the mobile drawer —
+   [role="dialog"] — keeps its default background). */
+.chat-assistant-sheet:not([role="dialog"]) {
+  background-color: var(--chat-input-bg) !important;
 }
 
 .chat-assistant-floating-input::before {
@@ -2078,8 +2283,40 @@ body::after {
   position: relative;
 }
 
-/* Search button needs position:relative so its grain ::after anchors to it. */
+/* Search button: --border outline (no ring/shadow); position:relative so its
+   grain ::after anchors to it. */
 #search-bar-entry {
+  position: relative;
+  border: 1px solid var(--border) !important;
+  box-shadow: none !important;
+}
+
+/* Theme toggle: match the toolbar outline (--border, sharp) + --primary icon,
+   with the Book-a-meeting hover (--hover surface). */
+#theme-preference-menu-trigger {
+  height: 100% !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 0 !important;
+  color: var(--primary) !important;
+  box-shadow: none !important;
+  transition: var(--transition-hover) !important;
+}
+
+#theme-preference-menu-trigger:hover {
+  background: var(--hover) !important;
+}
+
+#theme-preference-menu-trigger svg {
+  color: var(--primary) !important;
+}
+
+/* space-x-4 containers: 8px inline gap between children. */
+:where(.space-x-4 > :not(:last-child)) {
+  margin-inline-end: var(--space-8) !important;
+}
+
+/* Search modal needs position:relative so its grain ::after anchors to it. */
+[data-component-part="search-modal"] {
   position: relative;
 }
 
@@ -2089,7 +2326,9 @@ body::after {
 #sidebar::after,
 #mobile-nav::after,
 #search-bar-entry::after,
+#assistant-entry::after,
 .chat-assistant-sheet::after,
+[data-component-part="search-modal"]::after,
 [data-radix-menu-content]::after,
 [data-component-part="theme-preference-menu-content"]::after,
 [role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {
@@ -2117,7 +2356,9 @@ body::after {
   #sidebar::after,
   #mobile-nav::after,
   #search-bar-entry::after,
+  #assistant-entry::after,
   .chat-assistant-sheet::after,
+  [data-component-part="search-modal"]::after,
   [data-radix-menu-content]::after,
   [data-component-part="theme-preference-menu-content"]::after,
   [role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {

--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -1455,12 +1455,6 @@ html.dark
   margin-top: var(--space-16) !important;
 }
 
-[data-component-part="card-content-container"] {
-  padding: 0 !important;
-  padding-block: 0 !important;
-  padding-inline: 0 !important;
-}
-
 .prose :where(li):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: var(--spacing-mdx-content-prose-li) !important;
   margin-bottom: var(--spacing-mdx-content-prose-li) !important;
@@ -1708,7 +1702,7 @@ html.dark div.card svg {
 
 /* Content container */
 [data-component-part="card-content-container"] {
-  padding: var(--space-32) var(--space-32) !important;
+  padding: var(--space-32) !important;
   display: flex !important;
   flex-direction: column !important;
   gap: var(--space-24) !important;


### PR DESCRIPTION
Refactor the Mintlify theme layer into a consistent, token-driven system and
apply a batch of component styling fixes.

Design tokens
- Spacing scale: add --space-6/10/12/14; replace hardcoded px with tokens
- Color: promote the code palette (--blog-code-*) to :root single-source,
  add --code-hover-overlay / --code-tab-hover, dedupe --code-group-border
- Motion: --ease-standard, --duration-fast/base/shift, --transition-hover
- Typography: --font-sans / --font-mono, --font-weight-* scale
- Semantic tints: --nav-tint, --toc-rail; reuse --primary-muted
- Dropdown: --dropdown-hover (light --hover / dark --hover-alt)
- Prune dead tokens; fix --spacing-footer-top typo

Structure & cleanup
- Consistent section banners; trim junk comments
- SYSTEM NOTES block: breakpoints + Mintlify-coupled selectors (upgrade audit)
- Drop unused Supply Ultralight @font-face

Component adjustments
- Header/title max-width, spacing; copy-page CTA responsive swap (viewport)
- Tabs, accordions (grouped, connectors, open border), steps, cards
- Blockquote restyle; code blocks always sharp-cornered (--code-block-radius)
- Grain layer extended to theme menu, mobile menu, search button
- Prose heading/list/hr spacing; table + dropdown theming