### PR TITLE
[RELEASE] Release v0.8.0 of Nixtla client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "nixtla"
-version = "0.8.0.dev0"
+version = "0.8.0"
 description = "Python SDK for Nixtla API (TimeGPT)"
 authors = [
     {name = "Nixtla", email = "business@nixtla.io"}

--- a/uv.lock
+++ b/uv.lock
@@ -2920,7 +2920,7 @@ wheels = [
 
 [[package]]
 name = "nixtla"
-version = "0.8.0.dev0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
Key functionalities enabled by this client:
* By default, users are using model="timegpt-2.1" if model parameter is not specified. This requires the users to have eligible access to timegpt-2.1 model.
* When add_history=True, users shall forecast with "add_history=True" specified for cross-validation at server side. See https://github.com/Nixtla/nixtla/pull/824