### PR TITLE
fix(docs): redirect four stale slugs that 404 on nixtla.io/docs

### DIFF
--- a/timegpt-docs/docs.json
+++ b/timegpt-docs/docs.json
@@ -326,6 +326,22 @@
     {
       "source": "/exogenous-variables/forecasting/exogenous-variables/data_requirements/multiple_series#exogenous-variables",
       "destination": "/data_requirements/multiple_series#exogenous-variables"
+    },
+    {
+      "source": "/introduction/introduction/faq",
+      "destination": "/introduction/faq"
+    },
+    {
+      "source": "/tutorials-exogenous_variables-tutorials-holidays_and_special_dates",
+      "destination": "/forecasting/exogenous-variables/holiday_and_special_dates"
+    },
+    {
+      "source": "/tutorials-exogenous_variables-tutorials-categorical_variables",
+      "destination": "/forecasting/exogenous-variables/categorical_features"
+    },
+    {
+      "source": "/forecasting/evaluation/forecasting/evaluation/evaluation_metrics",
+      "destination": "/forecasting/evaluation/evaluation_metrics"
     }
   ],
   "contextual": {


### PR DESCRIPTION
## What

Adds four entries to `timegpt-docs/docs.json`'s `redirects` array for stale doc slugs that currently 404 on `nixtla.io/docs`.

## Why

An audit of the `Nixtla/web` repo cross-referenced Vercel production runtime logs against an Ahrefs Site Audit crawl (both from 2026-08-08) and found the same four broken URLs independently, confirming real traffic still hits them:

| Stale URL | Hits (24h, web repo logs) |
| --- | --- |
| `/introduction/introduction/faq` | 12 |
| `/tutorials-exogenous_variables-tutorials-holidays_and_special_dates` | 9 |
| `/tutorials-exogenous_variables-tutorials-categorical_variables` | 8 |
| `/forecasting/evaluation/forecasting/evaluation/evaluation_metrics` | (flagged by Ahrefs) |

These are the exact same class of stale slug already handled by the 26 existing entries in this file's `redirects` array (old flat `tutorials-x-tutorials-y` slugs, doubled `introduction/introduction/...` segments from a prior redirect bug). None of these four were covered.

A first attempt fixed this in the `web` repo's `next.config.mjs` ([Nixtla/web#788](https://github.com/Nixtla/web/pull/788)), but that was the wrong repo: `web` only proxies `/docs/:path*` to Mintlify, this file is where the actual docs content, navigation, and redirects live. That PR was closed in favor of this one, and `web`'s CLAUDE.md/AGENTS.md/README were updated to document the boundary going forward ([Nixtla/web#789](https://github.com/Nixtla/web/pull/789)).

## How

Each destination was verified live (200) before being added:

- `/introduction/introduction/faq` to `/introduction/faq`
- `/tutorials-exogenous_variables-tutorials-holidays_and_special_dates` to `/forecasting/exogenous-variables/holiday_and_special_dates`
- `/tutorials-exogenous_variables-tutorials-categorical_variables` to `/forecasting/exogenous-variables/categorical_features`
- `/forecasting/evaluation/forecasting/evaluation/evaluation_metrics` to `/forecasting/evaluation/evaluation_metrics`

All four destinations already exist in the `navigation` section of this same `docs.json`.

## Testing

- `docs.json` validated as well formed JSON.
- Confirmed no existing `redirects` entry already covers any of these four sources.
- Live checked all four old URLs (404) and all four new destinations (200) before adding.

## Checklist

- [x] Title follows conventional commits format
- [x] PR is focused on a single concern
- [x] Self reviewed the diff before requesting review
- [x] No secrets, credentials, or PII in the diff