### PR TITLE
docs: fix language errors and canonical host

### DIFF
--- a/timegpt-docs/data_requirements/multiple_series.mdx
+++ b/timegpt-docs/data_requirements/multiple_series.mdx
@@ -32,7 +32,7 @@ df.groupby('unique_id').head(1)
 
 Above, we can see that we have four unique series in the dataset, as there are four different values in `unique_id`. Note that each series can start at different dates.
 
-To forecast mutliple series, we can simply call:
+To forecast multiple series, we can simply call:
 
 ```python Multiple Series Forecast Example
 fcst = nixtla_client.forecast(df=df, h=24)

--- a/timegpt-docs/docs.json
+++ b/timegpt-docs/docs.json
@@ -17,7 +17,7 @@
   },
   "seo": {
     "metatags": {
-      "canonical": "https://nixtla.io/docs"
+      "canonical": "https://www.nixtla.io/docs"
     }
   },
   "icons": {

--- a/timegpt-docs/forecasting/evaluation/evaluation_metrics.mdx
+++ b/timegpt-docs/forecasting/evaluation/evaluation_metrics.mdx
@@ -18,7 +18,7 @@ The following table summarizes the common evaluation metrics used in forecasting
 | MAPE   | Point forecast         | <ul><li>expressed as a percentage</li><li>easy to interpret</li><li>favors under-forecasts</li></ul>                                                                 | When data has zero values                       |
 | sMAPE  | Point forecast         | <ul><li>robust to over- and under-forecasts</li><li>expressed as a percentage</li><li>easy to interpret</li></ul>                                                    | When data has zero values                       |
 | MASE   | Point forecast         | <ul><li>like the MAE, but scaled by the naive forecast</li><li>inherently compares to a simple benchmark</li><li>requires technical knowledge to interpret</li></ul> | There is only one series to evaluate            |
-| CRPS   | Probabilistic forecast | <ul><li>generalizaed MAE for probabilistic forecasts</li><li>requires technical knowledge to interpret</li></ul>                                                     | When evaluating point forecasts                 |
+| CRPS   | Probabilistic forecast | <ul><li>generalized MAE for probabilistic forecasts</li><li>requires technical knowledge to interpret</li></ul>                                                     | When evaluating point forecasts                 |
 
 In the following sections, we dive deeper into each metric. Note that all of these metrics can be used to evaluate the forecasts of TimeGPT using the _utilsforecast_ library. For more information, read our tutorial on [evaluating TimeGPT with utilsforecast](/forecasting/evaluation/evaluation_utilsforecast).
 
@@ -26,9 +26,9 @@ In the following sections, we dive deeper into each metric. Note that all of the
 
 The mean absolute error simply averages the absolute distance between the forecasts and the actual values.
 
-It is a good evaluation metric that works in the vast majority of forecasting tasks. It is robust to outliers, meaning that it will not magnifiy large errors, and it is expressed as the same units as the data, making it easy to interpret.
+It is a good evaluation metric that works in the vast majority of forecasting tasks. It is robust to outliers, meaning that it will not magnify large errors, and it is expressed as the same units as the data, making it easy to interpret.
 
-Simply be careful when average the MAE over multiple series of different scales, since then a series with smaller values might bring down the MAE, while a series with larger values will bring it up.
+Simply be careful when averaging the MAE over multiple series of different scales, since then a series with smaller values might bring down the MAE, while a series with larger values will bring it up.
 
 ## Mean Squared Error (MSE)
 
@@ -54,7 +54,7 @@ MAPE is excellent for comparing forecast accuracy across different time series w
 
 Avoid MAPE when your data contains zero or near-zero values (causes division by zero) or when you have intermittent demand patterns.
 
-Not that it's also asymmetric, penalizing positive errors (over-forecasts) more heavily than negative errors (under-forecasts).
+Note that it's also asymmetric, penalizing positive errors (over-forecasts) more heavily than negative errors (under-forecasts).
 
 ## Symmetric Mean Absolute Percentage Error (sMAPE)
 

--- a/timegpt-docs/forecasting/exogenous-variables/date_features.mdx
+++ b/timegpt-docs/forecasting/exogenous-variables/date_features.mdx
@@ -123,7 +123,7 @@ patterns. Including these features can help the model make better forecasts.
 
 > NOTE:
 > 1. In order to show how these features are created, we can add the
-`feature_contribution` agrument. This is just for demonstration purposes in this
+`feature_contribution` argument. This is just for demonstration purposes in this
 tutorial and not truly needed to forecast with datetime features.
 > 2. If you have a weekly frequency dataset, you can use
 `date_features = ["week", "month", "year"]` or a subset of these features.
@@ -262,7 +262,7 @@ is very close to 2024-01-01 (week 1). This will ensure that the learned features
 for week 52 will be close to those for week 1. This has also helped us get the
 feature cardinality down from 53 (in case of one hot encoding) to only 2 features.
 
-In our example, we have the hour feature wich has a relatively high cardinality
+In our example, we have the hour feature which has a relatively high cardinality
 after one hot encoding. Let's encode this with sine and cosine features and use
 this instead of the one hot encoding.
 
@@ -301,7 +301,7 @@ features.tail()
 | 2023-01-02 01:00:00 |   0.2588 |   0.9659 |
 
 In order to use this custom datetime feature, we can simply pass an instance of
-the class to the `date_features` argument. Since this is alreay encoded, we do
+the class to the `date_features` argument. Since this is already encoded, we do
 not need to include it in the `date_features_to_one_hot` argument.
 
 ```python

--- a/timegpt-docs/introduction/faq.mdx
+++ b/timegpt-docs/introduction/faq.mdx
@@ -153,8 +153,8 @@ icon: "circle-question-mark"
 
     <Accordion title="What if my API key isn't validating?">
       When you validate your API key and it returns `False`:
-      * If you are targeting an Azure endpoint, getting `False` from the `NixtlaClient.validate_api_key` method is expected. You can skip this step when targeting an Azure endpoint and proceed diretly to forecasting instead.
-      * If you are not taregting an Azure endpoint, then you should check the following:
+      * If you are targeting an Azure endpoint, getting `False` from the `NixtlaClient.validate_api_key` method is expected. You can skip this step when targeting an Azure endpoint and proceed directly to forecasting instead.
+      * If you are not targeting an Azure endpoint, then you should check the following:
         * Make sure you are using the latest version of the SDK (Python or R).
         * Check that your API key is active in your dashboard by visiting https://www.nixtla.io/book-a-free-trial?utm_source=nixtla.io&utm_campaign=/docs/introduction/faq.
         * Consider any firewalls your organization might have. There may be restricted access. If so, you can whitelist our endpoint https://api.nixtla.io/.

--- a/timegpt-docs/openapi.json
+++ b/timegpt-docs/openapi.json
@@ -76,7 +76,7 @@
     "/v2/anomaly_detection": {
       "post": {
         "summary": "Foundational Time Series Model Multi Series Anomaly Detector",
-        "description": "Based on the provided data, this endpoint detects the anomalies in the historical perdiod of multiple time series at once. It takes a JSON as an input containing information like the series frequency and historical data. (See below for a full description of the parameters.) The response contains a flag indicating if the date has an anomaly and also provides the prediction interval used to define if an observation is an anomaly.Get your token at https://nixtla.io/free-trial?utm_source=nixtla.io&utm_campaign=/docs/api-reference.",
+        "description": "Based on the provided data, this endpoint detects the anomalies in the historical period of multiple time series at once. It takes a JSON as an input containing information like the series frequency and historical data. (See below for a full description of the parameters.) The response contains a flag indicating if the date has an anomaly and also provides the prediction interval used to define if an observation is an anomaly. Get your token at https://nixtla.io/free-trial?utm_source=nixtla.io&utm_campaign=/docs/api-reference.",
         "operationId": "v2_anomaly_detection_v2_anomaly_detection_post",
         "requestBody": {
           "content": {

--- a/timegpt-docs/reference/sdk_reference.mdx
+++ b/timegpt-docs/reference/sdk_reference.mdx
@@ -370,10 +370,9 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 | plot_random | bool | True | Select time series to plot randomly. |
 | max_ids | int | 8 | Maximum number of ids to plot. |
 | models | Optional | None | list of models to plot. |
-| level | Optional | None | list of prediction intervals to plot if paseed. |
+| level | Optional | None | list of prediction intervals to plot if passed. |
 | max_insample_length | Optional | None | Max number of train/insample observations to be plotted. |
 | plot_anomalies | bool | False | Plot anomalies for each prediction interval. |
 | engine | Literal | matplotlib | Library used to plot. ‘matplotlib’, ‘plotly’ or ‘plotly-resampler’. |
-| resampler_kwargs | Optional | None | Kwargs to be passed to plotly-resampler constructor.<br/>For further custumization (“show_dash”) call the method,<br/>store the plotting object and add the extra arguments to<br/>its `show_dash` method. |
+| resampler_kwargs | Optional | None | Kwargs to be passed to plotly-resampler constructor.<br/>For further customization (“show_dash”) call the method,<br/>store the plotting object and add the extra arguments to<br/>its `show_dash` method. |
 | ax | Union | None | Object where plots will be added. |
-

--- a/timegpt-docs/setup/docker.mdx
+++ b/timegpt-docs/setup/docker.mdx
@@ -13,4 +13,4 @@ Benefits of using the Docker image are:
 - Full control over the server's hardware (CPU only or with GPU), maintenance and uptime
 - Data is secure as per your own guidelines
 
-The Docker image is available for entreprise customers. To request access to TimeGPT and deploy it on your own local infrastructure, [book a call with us](https://meetings.hubspot.com/cristian-challu/enterprise-contact-us?uuid=7a3723cd-153e-4901-a81c-f6cee9d6a6a3&utm_source=documentation&utm_medium=setup-docs&utm_campaign=docker-timegpt).
+The Docker image is available for enterprise customers. To request access to TimeGPT and deploy it on your own local infrastructure, [book a call with us](https://meetings.hubspot.com/cristian-challu/enterprise-contact-us?uuid=7a3723cd-153e-4901-a81c-f6cee9d6a6a3&utm_source=documentation&utm_medium=setup-docs&utm_campaign=docker-timegpt).


### PR DESCRIPTION
## What

Corrects confirmed spelling and grammar errors in the TimeGPT Mintlify documentation and aligns the canonical host with the production www domain.

## Why

The public documentation audit found objective language mistakes and a canonical mismatch. Mintlify emitted non www canonical and sitemap URLs while production redirected those URLs to www.

## How

1. Apply minimal corrections to the affected MDX pages.
2. Correct the anomaly detection OpenAPI description.
3. Set the Docs canonical base to `https://www.nixtla.io/docs`.
4. Preserve examples, links, page structure, and technical meaning.

## Testing

1. Parsed `timegpt-docs/openapi.json` and `timegpt-docs/docs.json` as valid JSON.
2. Confirmed the reported mistakes no longer appear in `timegpt-docs`.
3. Confirmed the configured canonical base is `https://www.nixtla.io/docs`.
4. Ran `git diff --check` and reviewed the complete diff.
5. Scanned additions for credentials and unintended files.

## Checklist

1. Title follows conventional commit format.
2. The pull request is limited to documentation quality and canonical metadata.
3. The complete diff was reviewed.
4. No secrets, credentials, or personal data were added.