### PR TITLE
fix(docs): canonicalize documentation host

### DIFF
--- a/timegpt-docs/docs.json
+++ b/timegpt-docs/docs.json
@@ -17,7 +17,7 @@
   },
   "seo": {
     "metatags": {
-      "canonical": "https://nixtla.io/docs"
+      "canonical": "https://www.nixtla.io/docs"
     }
   },
   "icons": {
@@ -180,7 +180,7 @@
         },
         {
           "anchor": "Meet with us",
-          "href": "https://nixtla.io/book-a-call?utm_source=nixtla.io&utm_campaign=/docs/timegpt/getting-started",
+          "href": "https://www.nixtla.io/book-a-call?utm_source=nixtla.io&utm_campaign=/docs/timegpt/getting-started",
           "icon": "calendar"
         }
       ]


### PR DESCRIPTION
## What

Updates the documentation canonical base to `https://www.nixtla.io` and sends the Meet with us navigation link directly to the same host.

## Why

All sampled documentation pages currently declare an apex canonical that redirects to the `www` host. The `www` host is already the canonical origin for the main website, so documentation pages should identify their direct final URL too.

This removes one redirect from each canonical signal and from the affected conversion link.

## How

* Changes `seo.metatags.canonical` in `timegpt-docs/docs.json`
* Changes the Meet with us URL in the same configuration
* Leaves the existing apex redirect unchanged

The documentation sitemap host is controlled independently by the Mintlify production domain. That setting will be updated and verified separately after this change lands.

## Testing

* Confirmed `timegpt-docs/docs.json` parses as valid JSON
* Confirmed no remaining apex host references exist in that file
* Confirmed the Mintlify preview emits page canonicals on `https://www.nixtla.io`
* All required pull request checks are green

## Checklist

* Scope is limited to two URL values
* No documentation content or navigation structure changed
* Canonical destination returns directly on the established host
