### PR TITLE
docs(styles): consolidate repeated style.css rules into shared CSS recipes

### DIFF
--- a/timegpt-docs/style.css
+++ b/timegpt-docs/style.css
@@ -256,26 +256,42 @@ p {
   line-height: 24px;
 }
 
-.eyebrow {
-  color: var(--primary-muted);
-  font-family: var(--font-mono) !important;
-  font-weight: var(--font-weight-regular) !important;
-  font-size: 14px;
-  text-transform: uppercase;
-  font-stretch: expanded;
-  line-height: 110%;
-}
-
+/* Mono-label recipe — single source for every small uppercase mono label
+   (eyebrows, sidebar/TOC titles, navbar links, banner, copy-page toolbar).
+   Size/leading vary per case via --label-size / --label-leading. */
+.eyebrow,
 .eyebrow-sm,
 #sidebar-title,
 #table-of-contents button,
-#table-of-contents button span {
+#table-of-contents button span,
+#navbar nav a,
+#banner p,
+#banner p a,
+#page-context-menu-button,
+#page-context-menu-button + button {
   font-family: var(--font-mono) !important;
   font-weight: var(--font-weight-regular) !important;
-  font-size: 12px !important;
-  text-transform: uppercase;
-  font-stretch: expanded;
-  line-height: 92%;
+  font-size: var(--label-size, 12px) !important;
+  text-transform: uppercase !important;
+  font-stretch: expanded !important;
+  line-height: var(--label-leading, 92%) !important;
+}
+
+/* Copy-page descendants: same face but WITHOUT forcing line-height — the label
+   spans keep Tailwind's text-sm leading (20px), which defines the text-shift
+   travel box; 92% shrinks it and the swap clips/janks. */
+#page-context-menu-button *,
+#page-context-menu-button + button * {
+  font-family: var(--font-mono) !important;
+  font-size: var(--label-size, 12px) !important;
+  text-transform: uppercase !important;
+  font-stretch: expanded !important;
+}
+
+.eyebrow {
+  --label-size: 14px;
+  --label-leading: 110%;
+  color: var(--primary-muted);
 }
 
 @media (max-width: 767px) {
@@ -283,7 +299,7 @@ p {
   #sidebar-title,
   #table-of-contents button,
   #table-of-contents button span {
-    line-height: 122%;
+    --label-leading: 122%;
   }
 }
 
@@ -299,22 +315,47 @@ p {
   background: var(--background);
 }
 
-html.dark #navbar-transition {
-  background: var(--background);
-}
-
+/* Mono-label recipe (BASE) at navbar size. */
 #navbar nav a {
-  font-family: var(--font-mono) !important;
-  font-weight: var(--font-weight-regular) !important;
-  font-size: 0.74375rem;
-  text-transform: uppercase;
-  font-stretch: expanded;
-  line-height: 92%;
+  --label-size: 0.74375rem;
 }
 
 #navbar nav ul > li:not(:last-child) {
   margin-inline-start: 0 !important;
   margin-inline-end: var(--space-8) !important;
+}
+
+/* ---- Toolbar outline button: shared chrome for every outlined control
+   (navbar links, Ask Assistant, Copy page + More actions, theme toggle).
+   Layout/geometry stay per case. ---- */
+#navbar nav li:not(#topbar-cta-button) a,
+#assistant-entry,
+#page-context-menu-button,
+#page-context-menu button[aria-haspopup="menu"],
+#theme-preference-menu-trigger {
+  background: var(--background) !important;
+  border-color: var(--border) !important;
+  color: var(--primary) !important;
+  box-shadow: none !important;
+  transition: var(--transition-hover) !important;
+}
+
+/* Standalone controls draw their own full border. The copy-page pair is NOT
+   here on purpose: it only recolors Mintlify's borders (the first button ships
+   border-r-0, so forcing a full border doubles the divider). */
+#navbar nav li:not(#topbar-cta-button) a,
+#assistant-entry,
+#theme-preference-menu-trigger {
+  border: 1px solid var(--border) !important;
+}
+
+#navbar nav li:not(#topbar-cta-button) a:hover,
+#assistant-entry:hover,
+#page-context-menu-button:hover,
+#page-context-menu button[aria-haspopup="menu"]:hover,
+#theme-preference-menu-trigger:hover {
+  background: var(--hover) !important;
+  color: var(--primary) !important;
 }
 
 #navbar nav li:not(#topbar-cta-button) a {
@@ -324,15 +365,6 @@ html.dark #navbar-transition {
   align-items: center !important;
   justify-content: center !important;
   line-height: 1 !important;
-  background: var(--background) !important;
-  border: 1px solid var(--border) !important;
-  color: var(--primary) !important;
-  transition: var(--transition-hover) !important;
-}
-
-#navbar nav li:not(#topbar-cta-button) a:hover {
-  background: var(--hover) !important;
-  color: var(--primary) !important;
 }
 
 #topbar-cta-button a {
@@ -376,45 +408,78 @@ html.dark #navbar-transition {
   color: transparent;
 }
 
+/* ---- Text-shift hover: ONE machinery for every label that slides out and is
+   replaced by its own copy. Each trigger sets --shift-label (and --shift-color
+   when the host text is transparent) on the element hosting the pseudos; the
+   geometry, motion and hover states live here once. ---- */
+
+#navbar nav li.navbar-link a {
+  --shift-label: "Book a meeting";
+}
+
+#navbar nav li:not(.navbar-link):not(#topbar-cta-button) a {
+  --shift-label: "Get Started";
+}
+
 #navbar nav li:not(#topbar-cta-button) a::before,
-#navbar nav li:not(#topbar-cta-button) a::after {
+#navbar nav li:not(#topbar-cta-button) a::after,
+#topbar-cta-button a div > span::before,
+#topbar-cta-button a div > span::after,
+#assistant-entry span::before,
+#assistant-entry span::after,
+#page-context-menu-button span.grid::after {
+  content: var(--shift-label);
   position: absolute;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--primary);
+  white-space: nowrap;
+  color: var(--shift-color, currentColor);
   transition: transform var(--duration-shift) var(--ease-standard);
   pointer-events: none;
 }
 
-#navbar nav li:not(#topbar-cta-button) a::before {
+/* Resting: visible layer at 0, incoming copy parked below. The topbar arrow
+   pseudos and the copy-page real label ride the same groups. */
+#navbar nav li:not(#topbar-cta-button) a::before,
+#topbar-cta-button a div > span::before,
+#topbar-cta-button a div::before,
+#assistant-entry span::before,
+#page-context-menu-button span.grid > span:not(.invisible) {
   transform: translateY(0);
 }
 
-#navbar nav li:not(#topbar-cta-button) a::after {
+#navbar nav li:not(#topbar-cta-button) a::after,
+#topbar-cta-button a div > span::after,
+#topbar-cta-button a div::after,
+#assistant-entry span::after,
+#page-context-menu-button span.grid::after {
   transform: translateY(var(--shift-distance));
 }
 
-#navbar nav li:not(#topbar-cta-button) a:is(:hover, :focus-visible)::before {
+/* Hover/focus: outgoing layer exits up, incoming copy settles at 0. */
+#navbar nav li:not(#topbar-cta-button) a:is(:hover, :focus-visible)::before,
+#topbar-cta-button a:is(:hover, :focus-visible) div > span::before,
+#topbar-cta-button a:is(:hover, :focus-visible) div::before,
+#assistant-entry:is(:hover, :focus-visible) span::before,
+#page-context-menu-button:is(:hover, :focus-visible)
+  span.grid
+  > span:not(.invisible) {
   transform: translateY(calc(-1 * var(--shift-distance)));
 }
 
-#navbar nav li:not(#topbar-cta-button) a:is(:hover, :focus-visible)::after {
+#navbar nav li:not(#topbar-cta-button) a:is(:hover, :focus-visible)::after,
+#topbar-cta-button a:is(:hover, :focus-visible) div > span::after,
+#topbar-cta-button a:is(:hover, :focus-visible) div::after,
+#assistant-entry:is(:hover, :focus-visible) span::after,
+#page-context-menu-button:is(:hover, :focus-visible) span.grid::after {
   transform: translateY(0);
 }
 
-#navbar nav li.navbar-link a::before,
-#navbar nav li.navbar-link a::after {
-  content: "Book a meeting";
-}
-
-#navbar nav li:not(.navbar-link):not(#topbar-cta-button) a::before,
-#navbar nav li:not(.navbar-link):not(#topbar-cta-button) a::after {
-  content: "Get Started";
-}
-
 #topbar-cta-button a div > span {
+  --shift-label: "Get Started";
+  --shift-color: var(--primary-foreground);
   position: relative;
   overflow: hidden;
   height: var(--button-height);
@@ -423,39 +488,10 @@ html.dark #navbar-transition {
   color: transparent !important;
 }
 
-#topbar-cta-button a div > span::before,
-#topbar-cta-button a div > span::after {
-  content: "Get Started";
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  white-space: nowrap;
-  color: var(--primary-foreground);
-  transition: transform var(--duration-shift) var(--ease-standard);
-  pointer-events: none;
-}
-
-#topbar-cta-button a div > span::before {
-  transform: translateY(0);
-}
-
-#topbar-cta-button a div > span::after {
-  transform: translateY(var(--shift-distance));
-}
-
-#topbar-cta-button a:is(:hover, :focus-visible) div > span::before {
-  transform: translateY(calc(-1 * var(--shift-distance)));
-}
-
-#topbar-cta-button a:is(:hover, :focus-visible) div > span::after {
-  transform: translateY(0);
-}
-
-/* Get Started arrow: the SAME reversible two-layer shift as the label. The inline
-   arrow can't be duplicated via content, so it's reproduced as a mask on the two
-   free pseudos of the content div; the real svg is hidden but keeps its width. */
+/* Get Started arrow: the inline arrow can't be duplicated via content, so it's
+   reproduced as a mask on the two free pseudos of the content div; the real svg
+   is hidden but keeps its width. Mechanics come from the icon-swap block below;
+   transforms ride the text-shift groups above (same trigger, same travel). */
 #topbar-cta-button a div {
   position: relative;
   overflow: hidden;
@@ -467,73 +503,86 @@ html.dark #navbar-transition {
 
 #topbar-cta-button a div::before,
 #topbar-cta-button a div::after {
-  content: "";
-  position: absolute;
+  --icon-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25'/%3E%3C/svg%3E");
+  --icon-mask-size: 0.75rem;
   right: 0;
   top: 0;
   bottom: 0;
   width: 0.75rem;
-  background-color: var(--primary-foreground);
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25'/%3E%3C/svg%3E")
-    center / 0.75rem no-repeat;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25'/%3E%3C/svg%3E")
-    center / 0.75rem no-repeat;
+}
+
+/* ---- Icon hover swap. Same technique + same --duration-shift as the text-shift
+   so text and icon move as one piece. Real icon hidden (or exiting), masked
+   pseudo copies ride the swap. Each case sets --icon-mask (+ --icon-mask-size)
+   and its own geometry; mechanics and transforms are shared here. ---- */
+#topbar-cta-button a div::before,
+#topbar-cta-button a div::after,
+#page-context-menu button[aria-haspopup="menu"]::before,
+#page-context-menu button[aria-haspopup="menu"]::after,
+#page-context-menu-button div::before,
+#page-context-menu-button div::after,
+#theme-preference-menu-trigger span[data-theme-preference-icon]::after,
+#assistant-entry::before {
+  content: "";
+  position: absolute;
+  background-color: currentColor;
+  -webkit-mask: var(--icon-mask) center / var(--icon-mask-size, contain)
+    no-repeat;
+  mask: var(--icon-mask) center / var(--icon-mask-size, contain) no-repeat;
   transition: transform var(--duration-shift) var(--ease-standard);
   pointer-events: none;
 }
 
-#topbar-cta-button a div::before {
+/* Icon-only swaps travel 150%; resting + hover states grouped per layer. */
+#page-context-menu button[aria-haspopup="menu"]::before,
+#page-context-menu-button div::before {
   transform: translateY(0);
 }
 
-#topbar-cta-button a div::after {
-  transform: translateY(var(--shift-distance));
+#page-context-menu button[aria-haspopup="menu"]::after,
+#page-context-menu-button div::after,
+#theme-preference-menu-trigger span[data-theme-preference-icon]::after,
+#assistant-entry::before {
+  transform: translateY(150%);
 }
 
-#topbar-cta-button a:is(:hover, :focus-visible) div::before {
-  transform: translateY(calc(-1 * var(--shift-distance)));
+#page-context-menu button[aria-haspopup="menu"]:hover::before,
+#page-context-menu-button:hover div::before {
+  transform: translateY(-150%);
 }
 
-#topbar-cta-button a:is(:hover, :focus-visible) div::after {
+#page-context-menu button[aria-haspopup="menu"]:hover::after,
+#page-context-menu-button:hover div::after,
+#theme-preference-menu-trigger:hover span[data-theme-preference-icon]::after,
+#assistant-entry:hover::before {
   transform: translateY(0);
 }
 
-/* ---- Icon hover swap. Same technique + same --duration-shift as the text-shift
-   so text and icon move as one piece. Real icon hidden; two masked pseudo layers
-   (or real-icon-exit + one masked pseudo where a pseudo is taken by grain). ---- */
+/* Real icons that exit on hover (their masked copy enters via the rules above). */
+#theme-preference-menu-trigger span[data-theme-preference-icon] > svg,
+#assistant-entry > svg {
+  transition: transform var(--duration-shift) var(--ease-standard);
+}
+
+#theme-preference-menu-trigger:hover span[data-theme-preference-icon] > svg,
+#assistant-entry:hover > svg {
+  transform: translateY(-150%);
+}
 
 /* Copy-page "More actions" chevron (icon-only; rotation baked into the mask so
    the swap is vertical). */
 #page-context-menu button[aria-haspopup="menu"] {
   position: relative;
+  border-radius: 0 !important;
 }
 #page-context-menu button[aria-haspopup="menu"] > svg {
   visibility: hidden;
 }
 #page-context-menu button[aria-haspopup="menu"]::before,
 #page-context-menu button[aria-haspopup="menu"]::after {
-  content: "";
-  position: absolute;
+  --icon-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25' transform='rotate(90 9 9)'/%3E%3C/svg%3E");
+  --icon-mask-size: 0.75rem;
   inset: 0;
-  background-color: currentColor;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25' transform='rotate(90 9 9)'/%3E%3C/svg%3E")
-    center / 0.75rem no-repeat;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.5 2.75L12.75 9L6.5 15.25' transform='rotate(90 9 9)'/%3E%3C/svg%3E")
-    center / 0.75rem no-repeat;
-  transition: transform var(--duration-shift) var(--ease-standard);
-  pointer-events: none;
-}
-#page-context-menu button[aria-haspopup="menu"]::before {
-  transform: translateY(0);
-}
-#page-context-menu button[aria-haspopup="menu"]::after {
-  transform: translateY(150%);
-}
-#page-context-menu button[aria-haspopup="menu"]:hover::before {
-  transform: translateY(-150%);
-}
-#page-context-menu button[aria-haspopup="menu"]:hover::after {
-  transform: translateY(0);
 }
 
 /* Copy-page button copy icon (icon+text; the label shifts via span.grid). */
@@ -548,32 +597,12 @@ html.dark #navbar-transition {
 }
 #page-context-menu-button div::before,
 #page-context-menu-button div::after {
-  content: "";
-  position: absolute;
+  --icon-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.25 5.25H7.25C6.14543 5.25 5.25 6.14543 5.25 7.25V14.25C5.25 15.3546 6.14543 16.25 7.25 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V7.25C16.25 6.14543 15.3546 5.25 14.25 5.25Z'/%3E%3Cpath d='M2.80103 11.998L1.77203 5.07397C1.61003 3.98097 2.36403 2.96397 3.45603 2.80197L10.38 1.77297C11.313 1.63397 12.19 2.16297 12.528 3.00097'/%3E%3C/svg%3E");
   left: 0;
   top: 50%;
   width: 1rem;
   height: 1rem;
   margin-top: -0.5rem;
-  background-color: currentColor;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.25 5.25H7.25C6.14543 5.25 5.25 6.14543 5.25 7.25V14.25C5.25 15.3546 6.14543 16.25 7.25 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V7.25C16.25 6.14543 15.3546 5.25 14.25 5.25Z'/%3E%3Cpath d='M2.80103 11.998L1.77203 5.07397C1.61003 3.98097 2.36403 2.96397 3.45603 2.80197L10.38 1.77297C11.313 1.63397 12.19 2.16297 12.528 3.00097'/%3E%3C/svg%3E")
-    center / contain no-repeat;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.25 5.25H7.25C6.14543 5.25 5.25 6.14543 5.25 7.25V14.25C5.25 15.3546 6.14543 16.25 7.25 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V7.25C16.25 6.14543 15.3546 5.25 14.25 5.25Z'/%3E%3Cpath d='M2.80103 11.998L1.77203 5.07397C1.61003 3.98097 2.36403 2.96397 3.45603 2.80197L10.38 1.77297C11.313 1.63397 12.19 2.16297 12.528 3.00097'/%3E%3C/svg%3E")
-    center / contain no-repeat;
-  transition: transform var(--duration-shift) var(--ease-standard);
-  pointer-events: none;
-}
-#page-context-menu-button div::before {
-  transform: translateY(0);
-}
-#page-context-menu-button div::after {
-  transform: translateY(150%);
-}
-#page-context-menu-button:hover div::before {
-  transform: translateY(-150%);
-}
-#page-context-menu-button:hover div::after {
-  transform: translateY(0);
 }
 
 /* Theme toggle (icon-only, 3 dynamic icons): real icon exits, matching masked
@@ -582,208 +611,82 @@ html.dark #navbar-transition {
 #theme-preference-menu-trigger {
   position: relative;
 }
-#theme-preference-menu-trigger span[data-theme-preference-icon] > svg {
-  transition: transform var(--duration-shift) var(--ease-standard);
-}
-#theme-preference-menu-trigger:hover span[data-theme-preference-icon] > svg {
-  transform: translateY(-150%);
-}
 #theme-preference-menu-trigger span[data-theme-preference-icon]::after {
-  content: "";
-  position: absolute;
+  --icon-mask-size: 1rem;
   inset: 0;
-  background-color: currentColor;
-  transition: transform var(--duration-shift) var(--ease-standard);
-  transform: translateY(150%);
-  pointer-events: none;
-}
-#theme-preference-menu-trigger:hover span[data-theme-preference-icon]::after {
-  transform: translateY(0);
 }
 #theme-preference-menu-trigger
   span[data-theme-preference-icon="system"]::after {
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4.5 15.5L9 14.5L13.5 15.5'/%3E%3Cpath d='M9 11.75V14.5'/%3E%3Cpath d='M14.25 2.75H3.75C2.64543 2.75 1.75 3.64543 1.75 4.75V9.75C1.75 10.8546 2.64543 11.75 3.75 11.75H14.25C15.3546 11.75 16.25 10.8546 16.25 9.75V4.75C16.25 3.64543 15.3546 2.75 14.25 2.75Z'/%3E%3C/svg%3E")
-    center / 1rem no-repeat;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4.5 15.5L9 14.5L13.5 15.5'/%3E%3Cpath d='M9 11.75V14.5'/%3E%3Cpath d='M14.25 2.75H3.75C2.64543 2.75 1.75 3.64543 1.75 4.75V9.75C1.75 10.8546 2.64543 11.75 3.75 11.75H14.25C15.3546 11.75 16.25 10.8546 16.25 9.75V4.75C16.25 3.64543 15.3546 2.75 14.25 2.75Z'/%3E%3C/svg%3E")
-    center / 1rem no-repeat;
+  --icon-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4.5 15.5L9 14.5L13.5 15.5'/%3E%3Cpath d='M9 11.75V14.5'/%3E%3Cpath d='M14.25 2.75H3.75C2.64543 2.75 1.75 3.64543 1.75 4.75V9.75C1.75 10.8546 2.64543 11.75 3.75 11.75H14.25C15.3546 11.75 16.25 10.8546 16.25 9.75V4.75C16.25 3.64543 15.3546 2.75 14.25 2.75Z'/%3E%3C/svg%3E");
 }
 #theme-preference-menu-trigger span[data-theme-preference-icon="light"]::after {
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 1.25V2.25'/%3E%3Cpath d='M14.48 3.52002L13.773 4.22702'/%3E%3Cpath d='M16.75 9H15.75'/%3E%3Cpath d='M14.48 14.4799L13.773 13.7729'/%3E%3Cpath d='M9 16.75V15.75'/%3E%3Cpath d='M3.52 14.4799L4.227 13.7729'/%3E%3Cpath d='M1.25 9H2.25'/%3E%3Cpath d='M3.52 3.52002L4.227 4.22702'/%3E%3Cpath d='M9 13.25C11.3472 13.25 13.25 11.3472 13.25 9C13.25 6.65279 11.3472 4.75 9 4.75C6.65279 4.75 4.75 6.65279 4.75 9C4.75 11.3472 6.65279 13.25 9 13.25Z'/%3E%3C/svg%3E")
-    center / 1rem no-repeat;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 1.25V2.25'/%3E%3Cpath d='M14.48 3.52002L13.773 4.22702'/%3E%3Cpath d='M16.75 9H15.75'/%3E%3Cpath d='M14.48 14.4799L13.773 13.7729'/%3E%3Cpath d='M9 16.75V15.75'/%3E%3Cpath d='M3.52 14.4799L4.227 13.7729'/%3E%3Cpath d='M1.25 9H2.25'/%3E%3Cpath d='M3.52 3.52002L4.227 4.22702'/%3E%3Cpath d='M9 13.25C11.3472 13.25 13.25 11.3472 13.25 9C13.25 6.65279 11.3472 4.75 9 4.75C6.65279 4.75 4.75 6.65279 4.75 9C4.75 11.3472 6.65279 13.25 9 13.25Z'/%3E%3C/svg%3E")
-    center / 1rem no-repeat;
+  --icon-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 1.25V2.25'/%3E%3Cpath d='M14.48 3.52002L13.773 4.22702'/%3E%3Cpath d='M16.75 9H15.75'/%3E%3Cpath d='M14.48 14.4799L13.773 13.7729'/%3E%3Cpath d='M9 16.75V15.75'/%3E%3Cpath d='M3.52 14.4799L4.227 13.7729'/%3E%3Cpath d='M1.25 9H2.25'/%3E%3Cpath d='M3.52 3.52002L4.227 4.22702'/%3E%3Cpath d='M9 13.25C11.3472 13.25 13.25 11.3472 13.25 9C13.25 6.65279 11.3472 4.75 9 4.75C6.65279 4.75 4.75 6.65279 4.75 9C4.75 11.3472 6.65279 13.25 9 13.25Z'/%3E%3C/svg%3E");
 }
 #theme-preference-menu-trigger span[data-theme-preference-icon="dark"]::after {
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M13 11.75C9.548 11.75 6.75 8.95201 6.75 5.50001C6.75 4.14801 7.183 2.90101 7.912 1.87801C4.548 2.50601 2 5.45301 2 9.00001C2 13.004 5.246 16.25 9.25 16.25C12.622 16.25 15.448 13.944 16.259 10.826C15.309 11.409 14.196 11.75 13 11.75Z'/%3E%3C/svg%3E")
-    center / 1rem no-repeat;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M13 11.75C9.548 11.75 6.75 8.95201 6.75 5.50001C6.75 4.14801 7.183 2.90101 7.912 1.87801C4.548 2.50601 2 5.45301 2 9.00001C2 13.004 5.246 16.25 9.25 16.25C12.622 16.25 15.448 13.944 16.259 10.826C15.309 11.409 14.196 11.75 13 11.75Z'/%3E%3C/svg%3E")
-    center / 1rem no-repeat;
+  --icon-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='none' stroke='%23000' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M13 11.75C9.548 11.75 6.75 8.95201 6.75 5.50001C6.75 4.14801 7.183 2.90101 7.912 1.87801C4.548 2.50601 2 5.45301 2 9.00001C2 13.004 5.246 16.25 9.25 16.25C12.622 16.25 15.448 13.944 16.259 10.826C15.309 11.409 14.196 11.75 13 11.75Z'/%3E%3C/svg%3E");
 }
 
 /* Assistant sparkle (icon+text; label shifts via its span). ::after is the grain,
    so the incoming copy uses ::before while the real sparkle exits. */
-#assistant-entry > svg {
-  transition: transform var(--duration-shift) var(--ease-standard);
-}
-#assistant-entry:hover > svg {
-  transform: translateY(-150%);
-}
 #assistant-entry::before {
-  content: "";
-  position: absolute;
+  --icon-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath d='M5.65799 2.99L4.39499 2.569L3.97399 1.306C3.83699 0.898 3.16199 0.898 3.02499 1.306L2.60399 2.569L1.34099 2.99C1.13699 3.058 0.998993 3.249 0.998993 3.464C0.998993 3.679 1.13699 3.87 1.34099 3.938L2.60399 4.359L3.02499 5.622C3.09299 5.826 3.28499 5.964 3.49999 5.964C3.71499 5.964 3.90599 5.826 3.97499 5.622L4.39599 4.359L5.65899 3.938C5.86299 3.87 6.00099 3.679 6.00099 3.464C6.00099 3.249 5.86199 3.058 5.65799 2.99Z' fill='%23000'/%3E%3Cpath d='M9.5 2.75L11.412 7.587L16.25 9.5L11.412 11.413L9.5 16.25L7.587 11.413L2.75 9.5L7.587 7.587L9.5 2.75Z' fill='none' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E");
   left: 12px;
   top: 50%;
   width: 1rem;
   height: 1rem;
   margin-top: -0.5rem;
-  background-color: currentColor;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath d='M5.65799 2.99L4.39499 2.569L3.97399 1.306C3.83699 0.898 3.16199 0.898 3.02499 1.306L2.60399 2.569L1.34099 2.99C1.13699 3.058 0.998993 3.249 0.998993 3.464C0.998993 3.679 1.13699 3.87 1.34099 3.938L2.60399 4.359L3.02499 5.622C3.09299 5.826 3.28499 5.964 3.49999 5.964C3.71499 5.964 3.90599 5.826 3.97499 5.622L4.39599 4.359L5.65899 3.938C5.86299 3.87 6.00099 3.679 6.00099 3.464C6.00099 3.249 5.86199 3.058 5.65799 2.99Z' fill='%23000'/%3E%3Cpath d='M9.5 2.75L11.412 7.587L16.25 9.5L11.412 11.413L9.5 16.25L7.587 11.413L2.75 9.5L7.587 7.587L9.5 2.75Z' fill='none' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E")
-    center / contain no-repeat;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath d='M5.65799 2.99L4.39499 2.569L3.97399 1.306C3.83699 0.898 3.16199 0.898 3.02499 1.306L2.60399 2.569L1.34099 2.99C1.13699 3.058 0.998993 3.249 0.998993 3.464C0.998993 3.679 1.13699 3.87 1.34099 3.938L2.60399 4.359L3.02499 5.622C3.09299 5.826 3.28499 5.964 3.49999 5.964C3.71499 5.964 3.90599 5.826 3.97499 5.622L4.39599 4.359L5.65899 3.938C5.86299 3.87 6.00099 3.679 6.00099 3.464C6.00099 3.249 5.86199 3.058 5.65799 2.99Z' fill='%23000'/%3E%3Cpath d='M9.5 2.75L11.412 7.587L16.25 9.5L11.412 11.413L9.5 16.25L7.587 11.413L2.75 9.5L7.587 7.587L9.5 2.75Z' fill='none' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E")
-    center / contain no-repeat;
-  transition: transform var(--duration-shift) var(--ease-standard);
-  transform: translateY(150%);
-  pointer-events: none;
-}
-#assistant-entry:hover::before {
-  transform: translateY(0);
 }
 
-/* "Ask Assistant" toolbar button — outline variant (like "Book a meeting") with
-   the same hover text-shift. Shift scoped to the label span so the sparkle icon
-   stays put. box-shadow/filter reset kills the ring + dark:brightness. */
+/* "Ask Assistant" — outline chrome from the toolbar-button molecule (NAVBAR);
+   filter reset kills Mintlify's dark:brightness. */
 #assistant-entry {
-  background: var(--background) !important;
-  border: 1px solid var(--border) !important;
-  box-shadow: none !important;
   filter: none !important;
-  color: var(--primary) !important;
-  transition: var(--transition-hover) !important;
   position: relative !important;
   overflow: hidden !important;
-}
-
-#assistant-entry:hover {
-  background: var(--hover) !important;
 }
 
 #assistant-entry svg {
   color: var(--primary) !important;
 }
 
+/* Label rides the shared text-shift machinery (NAVBAR section). */
 #assistant-entry span {
+  --shift-label: "Ask Assistant";
+  --shift-color: var(--primary);
   position: relative;
   overflow: hidden;
   color: transparent !important;
 }
 
-#assistant-entry span::before,
-#assistant-entry span::after {
-  content: "Ask Assistant";
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  white-space: nowrap;
-  color: var(--primary);
-  transition: transform var(--duration-shift) var(--ease-standard);
-  pointer-events: none;
-}
-
-#assistant-entry span::before {
-  transform: translateY(0);
-}
-
-#assistant-entry span::after {
-  transform: translateY(var(--shift-distance));
-}
-
-#assistant-entry:is(:hover, :focus-visible) span::before {
-  transform: translateY(calc(-1 * var(--shift-distance)));
-}
-
-#assistant-entry:is(:hover, :focus-visible) span::after {
-  transform: translateY(0);
-}
-
+/* Zeroes every text-shift / icon-swap transition at once — they all read
+   --duration-shift. */
 @media (prefers-reduced-motion: reduce) {
-  #navbar nav li:not(#topbar-cta-button) a::before,
-  #navbar nav li:not(#topbar-cta-button) a::after,
-  #topbar-cta-button a div > span::before,
-  #topbar-cta-button a div > span::after,
-  #assistant-entry span::before,
-  #assistant-entry span::after {
-    transition: none;
+  :root {
+    --duration-shift: 0s;
   }
 }
 
-#page-context-menu-button {
-  background: var(--background) !important;
-  border-color: var(--border) !important;
-  color: var(--primary) !important;
-  transition: var(--transition-hover) !important;
-}
-
-#page-context-menu-button:hover {
-  background: var(--hover) !important;
-}
-
-#page-context-menu button[aria-haspopup="menu"] {
-  background: var(--background) !important;
-  border-color: var(--border) !important;
-  color: var(--primary) !important;
-  transition: var(--transition-hover) !important;
-}
-
-#page-context-menu button[aria-haspopup="menu"]:hover {
-  background: var(--hover) !important;
-}
-
+/* Copy page + More actions: outline chrome from the toolbar-button molecule
+   (NAVBAR). */
 #page-context-menu button[aria-haspopup="menu"] svg {
   color: var(--primary) !important;
 }
 
+/* Label rides the shared text-shift machinery (NAVBAR section); the real label
+   span needs its own transition since it isn't a pseudo.
+   Travel is 170% here (not the global 115%): the label box is ~20px inside a
+   34px button, and clipping happens at the BUTTON's own overflow:hidden, so the
+   text must travel span-height + button padding to visibly reach the top edge
+   before vanishing — the same read as the navbar buttons. span.grid must NOT
+   clip (no overflow:hidden) or the swap dies at the text's own line box. */
 #page-context-menu-button span.grid {
+  --shift-label: "Copy page";
+  --shift-distance: 170%;
   position: relative;
-  overflow: hidden;
-}
-
-#page-context-menu-button span.grid > span:not(.invisible),
-#page-context-menu-button span.grid::after {
-  transition: transform var(--duration-shift) var(--ease-standard);
 }
 
 #page-context-menu-button span.grid > span:not(.invisible) {
-  transform: translateY(0);
-}
-
-#page-context-menu-button span.grid::after {
-  content: "Copy page";
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transform: translateY(var(--shift-distance));
-  pointer-events: none;
-}
-
-#page-context-menu-button:is(:hover, :focus-visible)
-  span.grid
-  > span:not(.invisible) {
-  transform: translateY(calc(-1 * var(--shift-distance)));
-}
-
-#page-context-menu-button:is(:hover, :focus-visible) span.grid::after {
-  transform: translateY(0);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  #page-context-menu-button span.grid > span:not(.invisible),
-  #page-context-menu-button span.grid::after {
-    transition: none;
-  }
+  transition: transform var(--duration-shift) var(--ease-standard);
 }
 
 /* CTA — secondary */
@@ -874,6 +777,11 @@ div:has(> div > #navigation-items) {
 
 .sidebar-group-header {
   font-weight: var(--font-weight-regular) !important;
+  text-transform: lowercase !important;
+}
+
+.sidebar-group-header h3::first-letter {
+  text-transform: uppercase !important;
 }
 
 #sidebar-title {
@@ -923,12 +831,8 @@ a.link {
   border: none !important;
 }
 
-.prose :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  font-weight: var(--font-weight-semibold) !important;
-}
-
 .prose
-  :where(strong):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  :where(a, strong):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   font-weight: var(--font-weight-semibold) !important;
 }
 
@@ -1026,37 +930,59 @@ pre code {
   content: none !important;
 }
 
-.code-block [data-component-part="code-block-root"],
-.code-block pre.shiki {
+/* ---- Shared code palette: applies to BOTH branches — the MDX .code-block and
+   the API-playground code-group (which has no .code-block inside). Same bg as
+   the MDX .code-block (--blog-code-bg #171614), not --code-group-bg (pure
+   #000), so the colors match across both. ---- */
+:is(.code-block, .code-group:not(:has(.code-block)))
+  [data-component-part="code-block-root"],
+:is(.code-block, .code-group:not(:has(.code-block))) pre.shiki {
   --shiki-dark-bg: var(--blog-code-bg) !important;
   background-color: var(--blog-code-bg) !important;
   color: var(--blog-code-text) !important;
+}
+
+.code-block [data-component-part="code-block-root"],
+.code-block pre.shiki {
   border-radius: 0 !important;
 }
 
-html:not(.dark) .code-block .shiki,
-html:not(.dark) .code-block .shiki span {
+html:not(.dark) :is(.code-block, .code-group:not(:has(.code-block))) .shiki,
+html:not(.dark)
+  :is(.code-block, .code-group:not(:has(.code-block)))
+  .shiki
+  span {
   color: var(--shiki-dark) !important;
 }
 
-.code-block [data-fade-overlay] {
+/* The playground renders in light theme with a white fade overlay
+   (--fade-color-light: #FFFFFF) that would show over the forced dark bg. */
+:is(.code-block, .code-group:not(:has(.code-block))) [data-fade-overlay] {
   display: none !important;
 }
 
-/* Copy button */
-.code-block [data-testid="copy-code-button"] {
+/* Copy button (both branches) */
+:is(.code-block, .code-group:not(:has(.code-block)))
+  [data-testid="copy-code-button"] {
   border: 1px solid var(--blog-code-border) !important;
   border-radius: 0 !important;
 }
-.code-block [data-testid="copy-code-button"],
-.code-block [data-testid="copy-code-button"] svg {
+:is(.code-block, .code-group:not(:has(.code-block)))
+  [data-testid="copy-code-button"],
+:is(.code-block, .code-group:not(:has(.code-block)))
+  [data-testid="copy-code-button"]
+  svg {
   color: var(--blog-code-muted) !important;
 }
-.code-block [data-testid="copy-code-button"]:hover,
-.code-block [data-testid="copy-code-button"]:hover svg {
+:is(.code-block, .code-group:not(:has(.code-block)))
+  [data-testid="copy-code-button"]:hover,
+:is(.code-block, .code-group:not(:has(.code-block)))
+  [data-testid="copy-code-button"]:hover
+  svg {
   color: var(--blog-code-text) !important;
 }
-.code-block [data-testid="copy-code-button"]:hover {
+:is(.code-block, .code-group:not(:has(.code-block)))
+  [data-testid="copy-code-button"]:hover {
   background-color: var(--code-hover-overlay) !important;
 }
 
@@ -1153,25 +1079,8 @@ body .code-group {
   display: none !important;
 }
 
-/* Same bg as the MDX .code-block (--blog-code-bg #171614), not --code-group-bg
-   (pure #000), so the colors match across both code-groups. */
-.code-group:not(:has(.code-block)) [data-component-part="code-block-root"],
-.code-group:not(:has(.code-block)) pre.shiki {
-  background-color: var(--blog-code-bg) !important;
-  --shiki-dark-bg: var(--blog-code-bg) !important;
-  color: var(--blog-code-text) !important;
-}
-html:not(.dark) .code-group:not(:has(.code-block)) .shiki,
-html:not(.dark) .code-group:not(:has(.code-block)) .shiki span {
-  color: var(--shiki-dark) !important;
-}
-
-/* The playground renders in light theme with a white fade overlay
-   (--fade-color-light: #FFFFFF) that shows over the forced black background.
-   Hidden the same way as in the .code-block branch (stable data-attribute). */
-.code-group:not(:has(.code-block)) [data-fade-overlay] {
-  display: none !important;
-}
+/* Shiki bg/text, light-mode span colors and the fade overlay for this branch
+   come from the shared code-palette :is(...) rules above. */
 
 /* The API playground code-group has no .code-block inside NOR role=tabpanel
    on its panels (unlike the MDX one: its panels are
@@ -1196,22 +1105,10 @@ html:not(.dark) .code-group:not(:has(.code-block)) .shiki span {
     border-radius: 0 !important;
   }
 }
+/* position:relative anchors its grain ::after — see the grain list in UTILITIES. */
 .code-group:not(:has(.code-block)) [data-component-part="code-block-root"] {
   border: 1px solid var(--blog-code-border) !important;
   position: relative;
-}
-.code-group:not(:has(.code-block))
-  [data-component-part="code-block-root"]::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  pointer-events: none;
-  background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
-  background-repeat: repeat;
-  background-size: var(--grain-size);
-  filter: grayscale(1) contrast(1.5);
-  opacity: var(--grain-opacity);
 }
 
 .code-group:not(:has(.code-block))
@@ -1231,24 +1128,6 @@ html:not(.dark) .code-group:not(:has(.code-block)) .shiki span {
   min-height: 2.25rem !important;
   position: relative;
 }
-/* Own grain on the playground header (same ::after as the code-block-root).
-   The body has per-element grain and it shows; the header only got the global
-   grain (fixed, fainter) and looked flat. pointer-events:none keeps the dropdown
-   and the copy button clickable. */
-.code-group:not(:has(.code-block))
-  > [data-component-part="code-group-tab-bar"]::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  background-image: url("/tex_noise.png"), url("/docs/tex_noise.png");
-  background-repeat: repeat;
-  background-size: var(--grain-size);
-  filter: grayscale(1) contrast(1.5);
-  opacity: var(--grain-opacity);
-}
-
 .code-group
   [data-component-part="code-group-tab-bar"]
   button[aria-haspopup="menu"]
@@ -1289,25 +1168,12 @@ html.dark
   color: var(--blog-code-text) !important;
 }
 
+/* Chrome comes from the shared copy-button rules above; only display needs
+   forcing here (the MDX branch hides its tab-bar copy button). */
 .code-group:not(:has(.code-block))
   > [data-component-part="code-group-tab-bar"]
   [data-testid="copy-code-button"] {
   display: flex !important;
-  border: 1px solid var(--blog-code-border) !important;
-  border-radius: 0 !important;
-  color: var(--blog-code-muted) !important;
-}
-.code-group:not(:has(.code-block))
-  > [data-component-part="code-group-tab-bar"]
-  [data-testid="copy-code-button"]:hover {
-  background-color: var(--code-hover-overlay) !important;
-  color: var(--blog-code-text) !important;
-}
-.code-group:not(:has(.code-block))
-  > [data-component-part="code-group-tab-bar"]
-  [data-testid="copy-code-button"]
-  svg {
-  color: inherit !important;
 }
 
 /* ==========================  TABLE OF CONTENTS  =========================== */
@@ -1393,19 +1259,13 @@ html.dark
 
 .prose
   span
-  + :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  + :where(h2, h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: var(--space-20) !important;
 }
 
 .prose :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: var(--spacing-mdx-content-prose-headers-small) !important;
   margin-bottom: 0 !important;
-}
-
-.prose
-  span
-  + :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  margin-top: var(--space-20) !important;
 }
 
 .prose
@@ -1424,54 +1284,7 @@ html.dark
   margin-bottom: 0 !important;
 }
 
-.prose :where(table):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-  width: 100%;
-  border-collapse: collapse;
-  border: 1px solid var(--table-border) !important;
-  background-color: var(--table-bg) !important;
-  font-size: 0.875rem;
-  color: var(--primary);
-}
-
-.prose
-  :where(table th):not(:where([class~="not-prose"], [class~="not-prose"] *)),
-.prose
-  :where(table td):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  padding: 0.875rem 1rem;
-  border-right: 1px solid var(--table-border) !important;
-  border-bottom: 1px solid var(--table-border) !important;
-  text-align: left;
-  vertical-align: middle;
-  font-weight: var(--font-weight-regular);
-  color: var(--primary);
-  background-color: transparent !important;
-}
-
-.prose
-  :where(table th):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  background-color: var(--table-header-bg) !important;
-  font-weight: var(--font-weight-semibold);
-}
-
-.prose
-  :where(table th:last-child):not(
-    :where([class~="not-prose"], [class~="not-prose"] *)
-  ),
-.prose
-  :where(table td:last-child):not(
-    :where([class~="not-prose"], [class~="not-prose"] *)
-  ) {
-  border-right: 0 !important;
-}
-
-.prose
-  :where(table tbody tr:last-child td):not(
-    :where([class~="not-prose"], [class~="not-prose"] *)
-  ) {
-  border-bottom: 0 !important;
-}
+/* Table styling (prose + [data-table-wrapper]) lives in the TABLES section. */
 
 .prose
   :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
@@ -1744,9 +1557,7 @@ div.card {
 }
 
 a.card:hover,
-div.card:hover,
-html.dark a.card:hover,
-html.dark div.card:hover {
+div.card:hover {
   background: var(--hover) !important;
   box-shadow: none !important;
   outline: none !important;
@@ -1947,6 +1758,19 @@ details.expandable .primitive-param-field {
 
 /* ================================  TABLES  ================================ */
 
+/* Two entry points, one look: plain prose tables and [data-table-wrapper]
+   (tables inside Cards render outside .mdx-content, so they can't rely on the
+   prose selectors). The frame lives on the table itself in prose and on the
+   wrapper otherwise; all cell chrome is shared below. */
+
+.prose :where(table):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  width: 100%;
+  border: 1px solid var(--table-border) !important;
+  background-color: var(--table-bg) !important;
+}
+
 [data-table-wrapper] {
   width: 100% !important;
   max-width: 100% !important;
@@ -1963,8 +1787,12 @@ details.expandable .primitive-param-field {
 [data-table-wrapper] table {
   margin: 0 !important;
   border: 0 !important;
-  border-collapse: collapse;
   background-color: transparent !important;
+}
+
+.prose :where(table):not(:where([class~="not-prose"], [class~="not-prose"] *)),
+[data-table-wrapper] table {
+  border-collapse: collapse;
   font-size: 0.875rem;
   color: var(--primary);
 }
@@ -1975,6 +1803,10 @@ details.expandable .primitive-param-field {
   background-color: transparent !important;
 }
 
+.prose
+  :where(table th):not(:where([class~="not-prose"], [class~="not-prose"] *)),
+.prose
+  :where(table td):not(:where([class~="not-prose"], [class~="not-prose"] *)),
 [data-table-wrapper] table th,
 [data-table-wrapper] table td {
   padding: 0.875rem 1rem;
@@ -1988,21 +1820,35 @@ details.expandable .primitive-param-field {
   background-color: transparent !important;
 }
 
-[data-table-wrapper] table thead th,
+.prose
+  :where(table th):not(:where([class~="not-prose"], [class~="not-prose"] *)),
 [data-table-wrapper] table th {
   background-color: var(--table-header-bg) !important;
   font-weight: var(--font-weight-semibold);
 }
 
+.prose
+  :where(table th:last-child):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ),
+.prose
+  :where(table td:last-child):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ),
 [data-table-wrapper] table th:last-child,
 [data-table-wrapper] table td:last-child {
   border-right: 0 !important;
 }
 
+.prose
+  :where(table tbody tr:last-child td):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  ),
 [data-table-wrapper] table tbody tr:last-child td {
   border-bottom: 0 !important;
 }
 
+/* Wrapper-only: first column stays centered. */
 [data-table-wrapper] table th:first-child,
 [data-table-wrapper] table td:first-child {
   text-align: center;
@@ -2054,16 +1900,7 @@ details.expandable .primitive-param-field {
   text-decoration-color: var(--primary) !important;
 }
 
-#banner p,
-#banner p a {
-  font-family: var(--font-mono) !important;
-  font-weight: var(--font-weight-regular) !important;
-  font-size: 12px !important;
-  text-transform: uppercase !important;
-  font-stretch: expanded !important;
-  line-height: 92% !important;
-}
-
+/* Font recipe comes from the mono-label rule in BASE. */
 #banner p a {
   text-decoration: underline !important;
   text-decoration-color: var(--primary) !important;
@@ -2093,7 +1930,7 @@ details.expandable .primitive-param-field {
 
 #pagination {
   font-family: var(--font-sans) !important;
-  font-size: 30px !important;
+  font-size: 28px !important;
   font-weight: var(--font-weight-regular) !important;
   line-height: 100% !important;
   color: var(--primary) !important;
@@ -2216,28 +2053,14 @@ details.expandable .primitive-param-field {
   color: transparent !important;
 }
 
+/* Font recipe + outline chrome come from the BASE mono-label rule and the
+   toolbar-button molecule (NAVBAR). */
 #page-context-menu-button,
 #page-context-menu-button + button {
   border-radius: 0 !important;
-  background-color: var(--background) !important;
-  color: var(--primary) !important;
-  font-family: var(--font-mono) !important;
-  font-weight: var(--font-weight-regular) !important;
-  font-size: 12px !important;
-  text-transform: uppercase !important;
-  font-stretch: expanded !important;
-  line-height: 92% !important;
   height: var(--button-height) !important;
   padding-top: 0 !important;
   padding-bottom: 0 !important;
-}
-
-#page-context-menu-button *,
-#page-context-menu-button + button * {
-  font-family: var(--font-mono) !important;
-  font-size: 12px !important;
-  text-transform: uppercase !important;
-  font-stretch: expanded !important;
 }
 
 /* =================================  TABS  ================================= */
@@ -2409,19 +2232,10 @@ body::after {
   box-shadow: none !important;
 }
 
-/* Theme toggle: match the toolbar outline (--border, sharp) + --primary icon,
-   with the Book-a-meeting hover (--hover surface). */
+/* Theme toggle: outline chrome from the toolbar-button molecule (NAVBAR). */
 #theme-preference-menu-trigger {
   height: 100% !important;
-  border: 1px solid var(--border) !important;
   border-radius: 0 !important;
-  color: var(--primary) !important;
-  box-shadow: none !important;
-  transition: var(--transition-hover) !important;
-}
-
-#theme-preference-menu-trigger:hover {
-  background: var(--hover) !important;
 }
 
 #theme-preference-menu-trigger svg {
@@ -2450,7 +2264,11 @@ body::after {
 [data-component-part="search-input-container"]::after,
 [data-radix-menu-content]::after,
 [data-component-part="theme-preference-menu-content"]::after,
-[role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {
+[role="dialog"]:has(> nav[aria-label="Mobile menu"])::after,
+.code-group:not(:has(.code-block))
+  [data-component-part="code-block-root"]::after,
+.code-group:not(:has(.code-block))
+  > [data-component-part="code-group-tab-bar"]::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -2467,27 +2285,23 @@ body::after {
   z-index: 11;
 }
 
+/* Playground header: grain below its children so the language dropdown and copy
+   button render clean on top. */
+.code-group:not(:has(.code-block))
+  > [data-component-part="code-group-tab-bar"]::after {
+  z-index: 0;
+}
+
 /* Grain follows the input's rounded-2xl so it doesn't poke past the corners. */
 [data-component-part="search-input-container"]::after {
   border-radius: inherit;
 }
 
+/* Every grain layer reads its opacity from this token, so zeroing it here kills
+   all of them (body, chrome, code-group) without repeating the selector list. */
 @media (prefers-contrast: more) {
-  body::after,
-  .grain-layer::after,
-  #navbar::after,
-  #banner::after,
-  #sidebar::after,
-  #mobile-nav::after,
-  #search-bar-entry::after,
-  #assistant-entry::after,
-  .chat-assistant-sheet::after,
-  [data-component-part="search-modal"]::after,
-  [data-component-part="search-input-container"]::after,
-  [data-radix-menu-content]::after,
-  [data-component-part="theme-preference-menu-content"]::after,
-  [role="dialog"]:has(> nav[aria-label="Mobile menu"])::after {
-    display: none;
+  :root {
+    --grain-opacity: 0;
   }
 }
 


### PR DESCRIPTION
## What

Following Mintlify's guidance on custom CSS styling, deduplicates repeated navbar/label/icon/code-block rules into shared "recipe" blocks parametrized with custom properties, instead of repeating the same declarations per selector.

1. Mono-label recipe — .eyebrow, .eyebrow-sm, #sidebar-title, TOC, navbar links, banner, and the copy-page toolbar now share one rule block driven by --label-size/--label-leading instead of repeating font-family/weight/transform/stretch everywhere.
2. Toolbar outline button — chrome (bg, border, color, box-shadow, hover) for navbar links, "Ask Assistant", "Copy page"/"More actions", and the theme toggle is now one grouped selector set, keeping the documented exception (the copy-page pair skips the full border: 1px solid since it already ships border-r-0).
3. Text-shift hover — the label slide/replace effect is now one mechanism reading content: var(--shift-label) / color: var(--shift-color, currentColor); each trigger only sets its own variables instead of duplicating the four transform rules.
4. Icon-swap — same pattern: one shared block with mask: var(--icon-mask) center / var(--icon-mask-size, contain); each icon (CTA arrow, "more actions" chevron, copy icon, theme toggle, assistant sparkle) only declares its --icon-mask + geometry.
5. A11y via tokens instead of selector lists — prefers-reduced-motion now just sets --duration-shift: 0s on :root; prefers-contrast: more sets --grain-opacity: 0. No more per-component selector lists.
6. Shared code palette between .code-block (MDX) and .code-group:not(:has(.code-block)) (API playground) via :is(...) — bg, shiki dark-text fix, fade-overlay hide, and copy-button chrome declared once.
7. Tables — unified styling for .prose table and [data-table-wrapper] table (needed because tables inside <Card> render outside .mdx-content).
8. Grain — every grain ::after (including the playground code-group ones) now lives in one master selector list in UTILITIES.
9. Small unrelated tweaks bundled in: .sidebar-group-header switched to lowercase + ::first-letter uppercase; .prose a and .prose strong merged into one selector; #pagination font-size dropped 30px → 28px; redundant html.dark prefixes removed from .card:hover rules.