### PR TITLE
docs: sync OpenAPI for nixtla-engine v0.3.2

### DIFF
--- a/timegpt-docs/openapi.json
+++ b/timegpt-docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Nixtla Forecast API",
     "description": "API for TimeGPT forecast. Just send your data as json and get results. We do the heavy lifting.",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "paths": {
     "/v2/forecast": {
@@ -73,10 +73,55 @@
         "x-fern-sdk-method-name": "v2/forecast"
       }
     },
+    "/v2/explain": {
+      "post": {
+        "summary": "Compute model-agnostic feature importance weights",
+        "description": "Compute model-agnostic feature importance weights for the provided exogenous features. It takes a JSON as an input containing the historical data with exogenous features and the attribution method to use. No foundation model is involved. The response contains one normalized weight per feature.",
+        "operationId": "v2_explain_v2_explain_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExplainInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExplainOutput"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "x-fern-sdk-method-name": "v2/explain"
+      }
+    },
     "/v2/anomaly_detection": {
       "post": {
         "summary": "Foundational Time Series Model Multi Series Anomaly Detector",
-        "description": "Based on the provided data, this endpoint detects the anomalies in the historical period of multiple time series at once. It takes a JSON as an input containing information like the series frequency and historical data. (See below for a full description of the parameters.) The response contains a flag indicating if the date has an anomaly and also provides the prediction interval used to define if an observation is an anomaly. Get your token at https://nixtla.io/free-trial?utm_source=nixtla.io&utm_campaign=/docs/api-reference.",
+        "description": "Based on the provided data, this endpoint detects the anomalies in the historical perdiod of multiple time series at once. It takes a JSON as an input containing information like the series frequency and historical data. (See below for a full description of the parameters.) The response contains a flag indicating if the date has an anomaly and also provides the prediction interval used to define if an observation is an anomaly.Get your token at https://nixtla.io/free-trial?utm_source=nixtla.io&utm_campaign=/docs/api-reference.",
         "operationId": "v2_anomaly_detection_v2_anomaly_detection_post",
         "requestBody": {
           "content": {
@@ -1352,6 +1397,63 @@
         ],
         "title": "CrossValidationOutput"
       },
+      "ExplainInput": {
+        "properties": {
+          "series": {
+            "$ref": "#/components/schemas/SeriesWithExogenous"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "granger",
+              "transfer_entropy"
+            ],
+            "title": "Method",
+            "description": "Model-agnostic causal analysis method used by the /v2/explain endpoint. Options are: 'granger' (default) and 'transfer_entropy'.",
+            "default": "granger"
+          }
+        },
+        "type": "object",
+        "required": [
+          "series"
+        ],
+        "title": "ExplainInput"
+      },
+      "ExplainOutput": {
+        "properties": {
+          "weights": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Weights"
+          },
+          "feature_names": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Names"
+          },
+          "method": {
+            "type": "string",
+            "title": "Method"
+          }
+        },
+        "type": "object",
+        "required": [
+          "weights",
+          "method"
+        ],
+        "title": "ExplainOutput"
+      },
       "FinetuneInput": {
         "properties": {
           "series": {
@@ -2098,6 +2200,88 @@
         ],
         "title": "OnlineAnomalyOutput"
       },
+      "SeriesWithExogenous": {
+        "properties": {
+          "X": {
+            "anyOf": [
+              {
+                "items": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X",
+            "description": "Historic values of the exogenous features. Each feature must be a list of the same size as the target (y)."
+          },
+          "categorical_exog": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer",
+                  "minimum": 0.0
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Categorical Exog",
+            "description": "Zero-based indices of the columns in X that are categorical features."
+          },
+          "y": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Y",
+            "description": "Historic values of the target."
+          },
+          "sizes": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Sizes",
+            "description": "Sizes of the individual series."
+          },
+          "start_datetime": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Datetime",
+            "description": "Starting timestamp of each individual series, as ISO 8601 strings (for example '2021-01-01' or '2021-01-01T09:30:00'). One entry per series, so it must have the same length as `sizes`. Together with `sizes` and `freq` this recovers the timestamps of every series."
+          }
+        },
+        "type": "object",
+        "required": [
+          "y",
+          "sizes"
+        ],
+        "title": "SeriesWithExogenous"
+      },
       "SeriesWithFutureExogenous": {
         "properties": {
           "X_future": {
@@ -2181,6 +2365,21 @@
             "type": "array",
             "title": "Sizes",
             "description": "Sizes of the individual series."
+          },
+          "start_datetime": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Datetime",
+            "description": "Starting timestamp of each individual series, as ISO 8601 strings (for example '2021-01-01' or '2021-01-01T09:30:00'). One entry per series, so it must have the same length as `sizes`. Together with `sizes` and `freq` this recovers the timestamps of every series."
           }
         },
         "type": "object",


### PR DESCRIPTION
## Sync OpenAPI doc for nixtla-engine v0.3.2

Propagates `openapi.json` from nixtla-engine into
`timegpt-docs/openapi.json` so the generated documentation matches the
released API surface.

Release notes: https://github.com/Nixtla/nixtla-engine/releases/tag/v0.3.2

🤖 Generated by the `release-deploy` workflow.
