### PR TITLE
docs: fix verified inaccuracies in TimeGPT docs, OpenAPI spec, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ The script will guide you through setting up external access integrations, confi
 
 Dive into our [comprehensive documentation](https://docs.nixtla.io/docs/getting-started-timegpt_quickstart) to discover examples and practical use cases for TimeGPT. Our documentation covers a wide range of topics, including:
 
-- **Getting Started**: Begin with our user-friendly [Quickstart Guide](https://docs.nixtla.io/docs/getting-started-timegpt_quickstart) and learn how to [set up your API key](https://docs.nixtla.io/docs/getting-started-setting_up_your_api_key) effortlessly.
+- **Getting Started**: Begin with our user-friendly [Quickstart Guide](https://docs.nixtla.io/docs/getting-started-timegpt_quickstart) and learn how to [set up your API key](https://www.nixtla.io/docs/setup/setting_up_your_api_key) effortlessly.
 
-- **Advanced Techniques**: Master advanced forecasting methods and learn how to enhance model accuracy with our tutorials on [anomaly detection](https://docs.nixtla.io/docs/tutorials-anomaly_detection), fine-tuning models using specific loss functions, and scaling computations across distributed frameworks such as [Spark, Dask, and Ray](https://docs.nixtla.io/docs/tutorials-computing_at_scale).
+- **Advanced Techniques**: Master advanced forecasting methods and learn how to enhance model accuracy with our tutorials on [anomaly detection](https://www.nixtla.io/docs/anomaly_detection/historical_anomaly_detection), fine-tuning models using specific loss functions, and scaling computations across distributed frameworks such as [Spark, Dask, and Ray](https://docs.nixtla.io/docs/tutorials-computing_at_scale).
 
-- **Specialized Topics**: Explore specialized topics like [handling exogenous variables](https://docs.nixtla.io/docs/tutorials-holidays_and_special_dates), model validation through [cross-validation](https://docs.nixtla.io/docs/tutorials-cross_validation), and strategies for [forecasting under uncertainty](https://docs.nixtla.io/docs/tutorials-uncertainty_quantification).
+- **Specialized Topics**: Explore specialized topics like [handling exogenous variables](https://docs.nixtla.io/docs/tutorials-holidays_and_special_dates), model validation through [cross-validation](https://www.nixtla.io/docs/forecasting/evaluation/cross_validation), and strategies for [forecasting under uncertainty](https://www.nixtla.io/docs/forecasting/probabilistic/introduction).
 
 - **Real World Applications**: Uncover how TimeGPT is applied in real-world scenarios through case studies on [forecasting web traffic](https://docs.nixtla.io/docs/use-cases-forecasting_web_traffic) and [predicting Bitcoin prices](https://docs.nixtla.io/docs/use-cases/bitcoin_price_prediction).
 

--- a/timegpt-docs/data_requirements/data_requirements.mdx
+++ b/timegpt-docs/data_requirements/data_requirements.mdx
@@ -26,6 +26,13 @@ TimeGPT accepts **pandas** and **polars** dataframes in [long format](https://ww
   </Card>
 </CardGroup>
 
+<Note>
+Your columns may have any names — tell the SDK which is which with `time_col`
+(default `ds`), `target_col` (default `y`), and, for multiple series, `id_col`
+(default `unique_id`). Many examples in these docs use `time_col='timestamp',
+target_col='value'`.
+</Note>
+
 <Check>
 TimeGPT also supports distributed dataframe libraries such as **dask**, **spark**, and **ray**.
 </Check>

--- a/timegpt-docs/forecasting/timegpt_2_family.mdx
+++ b/timegpt-docs/forecasting/timegpt_2_family.mdx
@@ -25,10 +25,10 @@ icon: "chart-line"
 
 ### Step 2: Install Nixtla
 
-Install the Nixtla library in your preferred Python environment. In order to use the TimeGPT-2 family of models, the client version must be >= 0.7.4.
+Install the Nixtla library in your preferred Python environment. In order to use the TimeGPT-2 family of models, the client version must be >= 0.7.4; we recommend installing the latest version.
 
 ```bash
-pip install nixtla>=0.7.4
+pip install "nixtla>=0.8.0"
 ```
 
 You can verify the client version installed using the following code. It should return a version >= 0.7.4

--- a/timegpt-docs/forecasting/timegpt_quickstart.mdx
+++ b/timegpt-docs/forecasting/timegpt_quickstart.mdx
@@ -26,8 +26,15 @@ TimeGPT is a production-ready generative pretrained transformer for time series 
 Install the Nixtla library in your preferred Python environment:
 
 ```bash
-pip install nixtla
+pip install "nixtla>=0.8.0"
 ```
+
+<Note>
+  This quickstart uses **TimeGPT-1**, which is available on all plans. The newer
+  [TimeGPT-2 family](/forecasting/timegpt_2_family) (`timegpt-2.1`) requires an
+  eligible paid plan — [book a call](https://www.nixtla.io/book-a-call?utm_source=docs&utm_medium=quickstart)
+  to upgrade.
+</Note>
 
 ### Step 3: Import the Nixtla TimeGPT client
 

--- a/timegpt-docs/introduction/about_timegpt.mdx
+++ b/timegpt-docs/introduction/about_timegpt.mdx
@@ -23,7 +23,7 @@ TimeGPT is a production-ready generative pretrained transformer model specifical
   <Step title="2. Choose Your Interface">
     You can access TimeGPT through:
 
-      - Self-hosted deployment on your infrastructure (recommended): [book a call](https://meetings.hubspot.com/cristian-challu/enterprise-contact-us?uuid=dc037f5a-d93b-4%5B…%5D90b-a611dd9460af&utm_source=github&utm_medium=pricing_page) for more information
+      - Self-hosted deployment on your infrastructure (recommended): [book a call](https://www.nixtla.io/book-a-call?utm_source=docs&utm_medium=pricing_page) for more information
       - Hosted APIs: start your [free trial](https://www.nixtla.io/book-a-free-trial?utm_source=nixtla.io&utm_campaign=/docs/introduction/about_timegpt)
       - Azure Studio (TimeGEN-1)
 

--- a/timegpt-docs/introduction/faq.mdx
+++ b/timegpt-docs/introduction/faq.mdx
@@ -84,11 +84,11 @@ icon: "circle-question-mark"
 
         <Tab title="REST API" icon="server">
           ```bash REST API Forecast Example
-          curl -X POST "https://api.nixtla.io/timegpt" \
+          curl -X POST "https://api.nixtla.io/v2/forecast" \
             -H "accept: application/json" \
-            -H "x-api-key: your_api_key" \
+            -H "Authorization: Bearer $NIXTLA_API_KEY" \
             -H "Content-Type: application/json" \
-            -d '{"df": [{"ds": "2023-01-01", "y": 100}, ...], "h": 7}'
+            -d '{"model": "timegpt-1", "series": {"y": [10, 12, 13, 11, 14, 15, 13, 12, 16, 17, 15, 14, 18, 19, 17, 16, 20, 21, 19, 18, 22, 23, 21, 20, 24, 25, 23, 22, 26, 27], "sizes": [30]}, "freq": "D", "h": 7}'
           ```
         </Tab>
       </Tabs>
@@ -124,18 +124,18 @@ icon: "circle-question-mark"
 
         <CodeBlock title="REST API Key Usage" icon="server">
           ```bash REST API Key Example
-          curl -X POST "https://api.nixtla.io/timegpt" \
+          curl -X POST "https://api.nixtla.io/v2/forecast" \
             -H "accept: application/json" \
-            -H "x-api-key: your_api_key" \
+            -H "Authorization: Bearer $NIXTLA_API_KEY" \
             -H "Content-Type: application/json" \
-            -d '{"df": [{"ds": "2023-01-01", "y": 100}, ...], "h": 7}'
+            -d '{"model": "timegpt-1", "series": {"y": [10, 12, 13, 11, 14, 15, 13, 12, 16, 17, 15, 14, 18, 19, 17, 16, 20, 21, 19, 18, 22, 23, 21, 20, 24, 25, 23, 22, 26, 27], "sizes": [30]}, "freq": "D", "h": 7}'
           ```
         </CodeBlock>
       </CodeGroup>
     </Accordion>
 
     <Accordion title="How can I check the status of my API key?">
-      Check your API key status with the [`validate_api_key` method](https://nixtlaverse.nixtla.io/nixtla/nixtla_client.html#nixtlaclient-validate-api-key) of the `NixtlaClient` class.
+      Check your API key status with the [`validate_api_key` method](/reference/sdk_reference) of the `NixtlaClient` class.
 
       ```python Validate API Key Example
       from nixtla import NixtlaClient
@@ -189,8 +189,12 @@ icon: "circle-question-mark"
     <h3 className="text-lg font-semibold mb-3">Common errors and warnings</h3>
 
     <Accordion title="Error message: Invalid API key">
-      ```python Invalid API Key Error
-      ApiError: status_code: 401, body: {'data': None, 'message': 'Invalid API key', 'details': 'Key not found', 'code': 'A12', 'requestID': 'E7F2BBTB2P', 'support': 'If you have questions or need support, please email support@nixtla.io'}
+      ```text Invalid API Key Error
+      # Missing Authorization header:
+      {"detail": "Not authenticated"}
+
+      # Invalid API key:
+      {"detail": "Provide a valid api key in the Authorization header in the format of 'Bearer <key>', get yours from https://nixtla.io/dashboard"}
       ```
 
       <Note>
@@ -199,7 +203,7 @@ icon: "circle-question-mark"
     </Accordion>
 
     <Accordion title="Error message: Too many requests">
-      ```python Too Many Requests Error
+      ```text Too Many Requests Error
       ApiError: status_code: 429, body: {'data': None, 'message': 'Too many requests', 'details': 'You need to add a payment method to continue using the API, do so from https://www.nixtla.io/book-a-free-trial?utm_source=nixtla.io&utm_campaign=/docs/introduction/faq', 'code': 'A21', 'requestID': 'NCJDK7KSJ6', 'support': 'If you have questions or need support, please email support@nixtla.io'}
       ```
 
@@ -210,7 +214,7 @@ icon: "circle-question-mark"
 
     <Accordion title="Error message: WriteTimeout">
       <Note>
-        A `WriteTimeout` error indicates the request exceeded allowable processing time. This commonly happens with large datasets. To fix this, increase the `num_partitions` parameter in the [`forecast` method](https://nixtlaverse.nixtla.io/nixtla/nixtla_client.html#nixtlaclient-forecast) of the `NixtlaClient` class, or use a distributed backend.
+        A `WriteTimeout` error indicates the request exceeded allowable processing time. This commonly happens with large datasets. To fix this, increase the `num_partitions` parameter in the [`forecast` method](/reference/sdk_reference) of the `NixtlaClient` class, or use a distributed backend.
       </Note>
     </Accordion>
   </Tab>
@@ -407,8 +411,8 @@ icon: "circle-question-mark"
           cv_results = client.cross_validation(
               df,
               h=7,
-              k=3,  # Number of folds
-              test_size=7  # Size of each test fold
+              n_windows=3,  # Number of validation windows
+              step_size=7   # Steps between window start points
           )
           ```
         </CodeBlock>
@@ -467,11 +471,9 @@ icon: "circle-question-mark"
     </Accordion>
 
     <Accordion title="Can TimeGPT handle missing values?">
-      <Warning>
-        TimeGPT cannot handle missing values or series with irregular timestamps.
-      </Warning>
+      Yes, with one condition. Missing target values can be supplied as `NaN`, but the series must have a continuous sequence of timestamps at its frequency — if there are gaps in the timestamp index, fill in the missing dates first.
 
-      For more information, see the [Forecasting Time Series with Irregular Timestamps](/forecasting/special-topics/irregular_timestamps) and [Dealing with Missing Values](/data_requirements/missing_values) tutorials.
+      For more information, see the [Dealing with Missing Values](/data_requirements/missing_values) and [Forecasting Time Series with Irregular Timestamps](/forecasting/special-topics/irregular_timestamps) tutorials.
     </Accordion>
   </Tab>
 
@@ -496,7 +498,7 @@ icon: "circle-question-mark"
     </Accordion>
 
     <Accordion title="Does TimeGPT support polars?">
-      Currently, TimeGPT does not support polars.
+      Yes. The Python SDK accepts both **pandas** and **polars** DataFrames in long format. See the [Data Requirements](/data_requirements/data_requirements) page and the polars example in the [Irregular Timestamps](/forecasting/special-topics/irregular_timestamps) tutorial. When using polars, set the `freq` argument explicitly (it cannot be inferred).
     </Accordion>
 
     <Accordion title="Does TimeGPT produce stable predictions?">
@@ -556,35 +558,24 @@ icon: "circle-question-mark"
       You can fine-tune the TimeGPT model, save it, and reuse it later. For detailed instructions, see our guide on [Re-using Fine-tuned Models](/forecasting/fine-tuning/save_reuse_delete_finetuned_models).
 
       <Tabs>
-        <Tab title="Save Model" icon="save">
-          ```python Save Fine-tuned Model
-          # Fine-tune and save the model
-          fine_tuned_parameters = client.forecast(
+        <Tab title="Fine-tune" icon="save">
+          ```python Fine-tune and Save
+          # Fine-tune the model; the result is stored on Nixtla's servers
+          # and identified by the returned id
+          finetuned_model_id = client.finetune(
               df,
-              h=7,
-              finetune_steps=100,
-              return_model=True  # Return the fine-tuned parameters
+              finetune_steps=100
           )
-
-          # Save to file
-          import pickle
-          with open("fine_tuned_model.pkl", "wb") as f:
-              pickle.dump(fine_tuned_parameters, f)
           ```
         </Tab>
 
-        <Tab title="Load Model" icon="folder-open">
-          ```python Load Fine-tuned Model
-          # Load the fine-tuned parameters
-          import pickle
-          with open("fine_tuned_model.pkl", "rb") as f:
-              fine_tuned_parameters = pickle.load(f)
-
-          # Use the fine-tuned model
+        <Tab title="Reuse" icon="folder-open">
+          ```python Reuse a Fine-tuned Model
+          # Use the fine-tuned model in later forecasts by passing its id
           forecast = client.forecast(
               new_df,
               h=7,
-              model=fine_tuned_parameters
+              finetuned_model_id=finetuned_model_id
           )
           ```
         </Tab>

--- a/timegpt-docs/introduction/timegpt_subscription_plans.mdx
+++ b/timegpt-docs/introduction/timegpt_subscription_plans.mdx
@@ -45,7 +45,7 @@ icon: "briefcase"
 ## Get in Touch
 
 If you'd like to explore custom plan options—for instance, adjusting the number of API calls, user limits, or support level—reach out to us at [support@nixtla.io](mailto:support@nixtla.io).\
-You can also schedule a demo through this [link](https://meetings.hubspot.com/cristian-challu/enterprise-contact-us?uuid=dc037f5a-d93b-4%5B…%5D90b-a611dd9460af&utm_source=github&utm_medium=pricing_page) to see TimeGPT in action and discuss your needs in more detail.
+You can also schedule a demo through this [link](https://www.nixtla.io/book-a-call?utm_source=docs&utm_medium=pricing_page) to see TimeGPT in action and discuss your needs in more detail.
 
 <Check>
   **Free Trial Available\!**\\
@@ -72,7 +72,7 @@ When you [**create your account**](https://www.nixtla.io/book-a-free-trial?utm_s
 <Info>
   **Pricing and Billing Information**\\
 
-Additional pricing details and frequently asked questions can be found on our [FAQ page](introduction/faq).
+For pricing tailored to your usage, [book a call with the Nixtla team](https://www.nixtla.io/book-a-call?utm_source=docs&utm_medium=pricing_page).
 
 </Info>
 

--- a/timegpt-docs/openapi.json
+++ b/timegpt-docs/openapi.json
@@ -60,9 +60,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
+                },
+                "example": {
+                  "detail": [
+                    {
+                      "loc": [
+                        "body",
+                        "h"
+                      ],
+                      "msg": "Field required",
+                      "type": "missing"
+                    }
+                  ],
+                  "request_id": "Q6CBLFWGR8"
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/ModelNotAllowed"
           }
         },
         "security": [
@@ -156,6 +175,12 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/ModelNotAllowed"
           }
         },
         "security": [
@@ -169,7 +194,7 @@
     "/v2/online_anomaly_detection": {
       "post": {
         "summary": "Foundational Time Series Model Online Multi Series Anomaly Detector",
-        "description": "This endpoint performs online anomaly detection based on the provided data. It uses cross-validation for more robust detection of anomalies and it supports detection for univariate and multivariate scenarios. It takes a JSON as an input containing information like the series frequency and historical data. (See below for a full description of the parameters.) The response contains a flag indicating if the date has an anomaly, it provides the prediction interval used to define if an observation is an anomaly, and it reports the associated z-score for each point. Get your token at https://nixtla.io/free-trial?utm_source=nixtla.io&utm_campaign=/docs/api-reference.",
+        "description": "This endpoint performs online anomaly detection based on the provided data. It uses cross-validation for more robust detection of anomalies and it supports detection for univariate and multivariate scenarios. It takes a JSON as an input containing information like the series frequency and historical data. (See below for a full description of the parameters.) The response contains a flag indicating if the date has an anomaly, it provides the prediction interval used to define if an observation is an anomaly, and it reports an anomaly score for each point (returned as `anomaly_score`). Get your token at https://nixtla.io/free-trial?utm_source=nixtla.io&utm_campaign=/docs/api-reference.",
         "operationId": "v2_online_anomaly_detection_v2_online_anomaly_detection_post",
         "requestBody": {
           "content": {
@@ -536,6 +561,12 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/ModelNotAllowed"
           }
         },
         "security": [
@@ -596,6 +627,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         },
         "x-excluded": true
@@ -659,6 +693,12 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/ModelNotAllowed"
           }
         },
         "security": [
@@ -754,6 +794,12 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/ModelNotAllowed"
           }
         },
         "security": [
@@ -779,6 +825,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         },
         "security": [
@@ -825,6 +874,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         },
         "security": [
@@ -862,6 +914,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         },
         "security": [
@@ -883,6 +938,9 @@
                 "schema": {}
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         },
         "security": [
@@ -903,12 +961,12 @@
           "freq": {
             "type": "string",
             "title": "Freq",
-            "description": "The frequency of the data represented as a string. 'D' for daily, 'M' for monthly, 'H' for hourly, and 'W' for weekly frequencies are available."
+            "description": "The frequency of the data as a pandas offset alias, e.g. `D` (daily), `W` (weekly), `MS` (month start), `M` (month end), `H` (hourly), `min` (minutely), `Q` (quarterly). See the pandas documentation on offset aliases: https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases"
           },
           "model": {
             "type": "string",
             "title": "Model",
-            "description": "Model to use as a string. Common options are (but not restricted to) `timegpt-1` and `timegpt-1-long-horizon.` Full options vary by different users. Contact support@nixtla.io for more information. We recommend using `timegpt-1-long-horizon` for forecasting if you want to predict more than one seasonal period given the frequency of your data.",
+            "description": "Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`, and the TimeGPT-2 family (e.g. `timegpt-2.1`), which requires an eligible paid plan. Use `timegpt-1-long-horizon` if you want to predict more than one seasonal period given the frequency of your data. Note: the API currently requires this field to be set explicitly (a request without it is rejected), despite the declared default. Contact support@nixtla.io for the full list of models available to your plan.",
             "default": "timegpt-1"
           },
           "clean_ex_first": {
@@ -963,7 +1021,7 @@
               }
             ],
             "title": "Hist Exog",
-            "description": "Zero-based indices of the exogenous features to treat as historical."
+            "description": "Zero-based indices into `series.X` (the list of exogenous feature arrays, not your original dataframe columns) of the features to treat as historical. Note: the Python SDK serializes features future-exogenous first (in `X_df` column order), then historical (in `hist_exog_list` order), so historical features occupy the trailing indices."
           },
           "level": {
             "anyOf": [
@@ -1079,7 +1137,7 @@
           "freq": {
             "type": "string",
             "title": "Freq",
-            "description": "The frequency of the data represented as a string. 'D' for daily, 'M' for monthly, 'H' for hourly, and 'W' for weekly frequencies are available."
+            "description": "The frequency of the data as a pandas offset alias, e.g. `D` (daily), `W` (weekly), `MS` (month start), `M` (month end), `H` (hourly), `min` (minutely), `Q` (quarterly). See the pandas documentation on offset aliases: https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases"
           },
           "n_windows": {
             "type": "integer",
@@ -1103,7 +1161,7 @@
           "model": {
             "type": "string",
             "title": "Model",
-            "description": "Model to use as a string. Common options are (but not restricted to) `timegpt-1` and `timegpt-1-long-horizon.` Full options vary by different users. Contact support@nixtla.io for more information. We recommend using `timegpt-1-long-horizon` for forecasting if you want to predict more than one seasonal period given the frequency of your data.",
+            "description": "Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`, and the TimeGPT-2 family (e.g. `timegpt-2.1`), which requires an eligible paid plan. Use `timegpt-1-long-horizon` if you want to predict more than one seasonal period given the frequency of your data. Note: the API currently requires this field to be set explicitly (a request without it is rejected), despite the declared default. Contact support@nixtla.io for the full list of models available to your plan.",
             "default": "timegpt-1"
           },
           "clean_ex_first": {
@@ -1214,7 +1272,7 @@
               }
             ],
             "title": "Hist Exog",
-            "description": "Zero-based indices of the exogenous features to treat as historical."
+            "description": "Zero-based indices into `series.X` (the list of exogenous feature arrays, not your original dataframe columns) of the features to treat as historical. Note: the Python SDK serializes features future-exogenous first (in `X_df` column order), then historical (in `hist_exog_list` order), so historical features occupy the trailing indices."
           },
           "refit": {
             "type": "boolean",
@@ -1360,12 +1418,12 @@
           "freq": {
             "type": "string",
             "title": "Freq",
-            "description": "The frequency of the data represented as a string. 'D' for daily, 'M' for monthly, 'H' for hourly, and 'W' for weekly frequencies are available."
+            "description": "The frequency of the data as a pandas offset alias, e.g. `D` (daily), `W` (weekly), `MS` (month start), `M` (month end), `H` (hourly), `min` (minutely), `Q` (quarterly). See the pandas documentation on offset aliases: https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases"
           },
           "model": {
             "type": "string",
             "title": "Model",
-            "description": "Model to use as a string. Common options are (but not restricted to) `timegpt-1` and `timegpt-1-long-horizon.` Full options vary by different users. Contact support@nixtla.io for more information. We recommend using `timegpt-1-long-horizon` for forecasting if you want to predict more than one seasonal period given the frequency of your data.",
+            "description": "Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`, and the TimeGPT-2 family (e.g. `timegpt-2.1`), which requires an eligible paid plan. Use `timegpt-1-long-horizon` if you want to predict more than one seasonal period given the frequency of your data. Note: the API currently requires this field to be set explicitly (a request without it is rejected), despite the declared default. Contact support@nixtla.io for the full list of models available to your plan.",
             "default": "timegpt-1"
           },
           "finetune_steps": {
@@ -1443,7 +1501,7 @@
               }
             ],
             "title": "Hist Exog",
-            "description": "Zero-based indices of the exogenous features to treat as historical."
+            "description": "Zero-based indices into `series.X` (the list of exogenous feature arrays, not your original dataframe columns) of the features to treat as historical. Note: the Python SDK serializes features future-exogenous first (in `X_df` column order), then historical (in `hist_exog_list` order), so historical features occupy the trailing indices."
           },
           "multivariate": {
             "type": "boolean",
@@ -1592,7 +1650,7 @@
           "freq": {
             "type": "string",
             "title": "Freq",
-            "description": "The frequency of the data represented as a string. 'D' for daily, 'M' for monthly, 'H' for hourly, and 'W' for weekly frequencies are available."
+            "description": "The frequency of the data as a pandas offset alias, e.g. `D` (daily), `W` (weekly), `MS` (month start), `M` (month end), `H` (hourly), `min` (minutely), `Q` (quarterly). See the pandas documentation on offset aliases: https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases"
           },
           "h": {
             "type": "integer",
@@ -1603,7 +1661,7 @@
           "model": {
             "type": "string",
             "title": "Model",
-            "description": "Model to use as a string. Common options are (but not restricted to) `timegpt-1` and `timegpt-1-long-horizon.` Full options vary by different users. Contact support@nixtla.io for more information. We recommend using `timegpt-1-long-horizon` for forecasting if you want to predict more than one seasonal period given the frequency of your data.",
+            "description": "Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`, and the TimeGPT-2 family (e.g. `timegpt-2.1`), which requires an eligible paid plan. Use `timegpt-1-long-horizon` if you want to predict more than one seasonal period given the frequency of your data. Note: the API currently requires this field to be set explicitly (a request without it is rejected), despite the declared default. Contact support@nixtla.io for the full list of models available to your plan.",
             "default": "timegpt-1"
           },
           "clean_ex_first": {
@@ -1836,7 +1894,7 @@
           "freq": {
             "type": "string",
             "title": "Freq",
-            "description": "The frequency of the data represented as a string. 'D' for daily, 'M' for monthly, 'H' for hourly, and 'W' for weekly frequencies are available."
+            "description": "The frequency of the data as a pandas offset alias, e.g. `D` (daily), `W` (weekly), `MS` (month start), `M` (month end), `H` (hourly), `min` (minutely), `Q` (quarterly). See the pandas documentation on offset aliases: https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases"
           },
           "detection_size": {
             "type": "integer",
@@ -1863,7 +1921,7 @@
           "model": {
             "type": "string",
             "title": "Model",
-            "description": "Model to use as a string. Common options are (but not restricted to) `timegpt-1` and `timegpt-1-long-horizon.` Full options vary by different users. Contact support@nixtla.io for more information. We recommend using `timegpt-1-long-horizon` for forecasting if you want to predict more than one seasonal period given the frequency of your data.",
+            "description": "Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`, and the TimeGPT-2 family (e.g. `timegpt-2.1`), which requires an eligible paid plan. Use `timegpt-1-long-horizon` if you want to predict more than one seasonal period given the frequency of your data. Note: the API currently requires this field to be set explicitly (a request without it is rejected), despite the declared default. Contact support@nixtla.io for the full list of models available to your plan.",
             "default": "timegpt-1"
           },
           "clean_ex_first": {
@@ -1964,7 +2022,7 @@
               }
             ],
             "title": "Hist Exog",
-            "description": "Zero-based indices of the exogenous features to treat as historical."
+            "description": "Zero-based indices into `series.X` (the list of exogenous feature arrays, not your original dataframe columns) of the features to treat as historical. Note: the Python SDK serializes features future-exogenous first (in `X_df` column order), then historical (in `hist_exog_list` order), so historical features occupy the trailing indices."
           },
           "refit": {
             "type": "boolean",
@@ -2237,11 +2295,65 @@
         "description": "HTTPBearer",
         "scheme": "bearer"
       }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Authentication failed.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "detail": {
+                  "type": "string"
+                }
+              }
+            },
+            "examples": {
+              "missing_header": {
+                "summary": "No Authorization header",
+                "value": {
+                  "detail": "Not authenticated"
+                }
+              },
+              "invalid_key": {
+                "summary": "Invalid API key",
+                "value": {
+                  "detail": "Provide a valid api key in the Authorization header in the format of 'Bearer <key>', get yours from https://nixtla.io/dashboard"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ModelNotAllowed": {
+        "description": "The requested model is not included in your subscription plan.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "detail": {
+                  "type": "string"
+                }
+              }
+            },
+            "example": {
+              "detail": "The requested model timegpt-2.1 is not allowed for your subscription plan. Re-confirm the allowed models in your subscription plan or email support@nixtla.io to upgrade your plan"
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
     {
       "url": "https://api.nixtla.io"
+    }
+  ],
+  "security": [
+    {
+      "HTTPBearer": []
     }
   ]
 }

--- a/timegpt-docs/reference/sdk_reference.mdx
+++ b/timegpt-docs/reference/sdk_reference.mdx
@@ -67,17 +67,15 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 >                         quantiles:Optional[list[float]]=None,
 >                         finetune_steps:typing.Annotated[int,Ge(ge=0)]=0,
 >                         finetune_depth:Literal[1,2,3,4,5]=1, finetune_loss
->                         :Literal['default','mae','mse','rmse','mape','smap
->                         e']='default',
+>                         :Literal['default','mae','mse','rmse','mape',
+>                         'smape','poisson']='default',
 >                         finetuned_model_id:Optional[str]=None,
 >                         clean_ex_first:bool=True,
 >                         hist_exog_list:Optional[list[str]]=None,
 >                         validate_api_key:bool=False,
 >                         add_history:bool=False, date_features:Union[bool,l
 >                         ist[Union[str,Callable]]]=False, date_features_to_
->                         one_hot:Union[bool,list[str]]=False, model:Literal
->                         ['azureai','timegpt-1','timegpt-1-long-
->                         horizon']='timegpt-1', num_partitions:Optional[Ann
+>                         one_hot:Union[bool,list[str]]=False, model:str='timegpt-2.1', num_partitions:Optional[Ann
 >                         otated[int,Gt(gt=0)]]=None,
 >                         feature_contributions:bool=False)
 > ```
@@ -97,7 +95,7 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 | quantiles | Optional | None | Quantiles to forecast, list between (0, 1).<br/>`level` and `quantiles` should not be used simultaneously.<br/>The output dataframe will have the quantile columns<br/>formatted as TimeGPT-q-(100 \* q) for each q.<br/>100 \* q represents percentiles but we choose this notation<br/>to avoid having dots in column names. |
 | finetune_steps | Annotated | 0 | Number of steps used to finetune learning TimeGPT in the<br/>new data. |
 | finetune_depth | Literal | 1 | The depth of the finetuning. Uses a scale from 1 to 5, where 1 means little finetuning,<br/>and 5 means that the entire model is finetuned. |
-| finetune_loss | Literal | default | Loss function to use for finetuning. Options are: `default`, `mae`, `mse`, `rmse`, `mape`, and `smape`. |
+| finetune_loss | Literal | default | Loss function to use for finetuning. Options are: `default`, `mae`, `mse`, `rmse`, `mape`, `smape`, and `poisson`. |
 | finetuned_model_id | Optional | None | ID of previously fine-tuned model to use. |
 | clean_ex_first | bool | True | Clean exogenous signal before making forecasts using TimeGPT. |
 | hist_exog_list | Optional | None | Column names of the historical exogenous features. |
@@ -105,7 +103,7 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 | add_history | bool | False | Return fitted values of the model. |
 | date_features | Union | False | Features computed from the dates.<br/>Can be pandas date attributes or functions that will take the dates as input.<br/>If True automatically adds most used date features for the<br/>frequency of `df`. |
 | date_features_to_one_hot | Union | False | Apply one-hot encoding to these date features.<br/>If `date_features=True`, then all date features are<br/>one-hot encoded by default. |
-| model | Literal | timegpt-1 | Model to use as a string. Options are: `timegpt-1`, and `timegpt-1-long-horizon`.<br/>We recommend using `timegpt-1-long-horizon` for forecasting<br/>if you want to predict more than one seasonal<br/>period given the frequency of your data. |
+| model | str | timegpt-2.1 | Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`,<br/>and the TimeGPT-2 family (e.g. `timegpt-2.1`, requires an eligible paid plan).<br/>Use `timegpt-1-long-horizon` to predict more than one seasonal<br/>period given the frequency of your data. |
 | num_partitions | Optional | None | Number of partitions to use.<br/>If None, the number of partitions will be equal<br/>to the available parallel resources in distributed environments. |
 | feature_contributions | bool | False |  |
 | **Returns** | **AnyDFType** |  | **DataFrame with TimeGPT forecasts for point predictions and probabilistic<br/>predictions (if level is not None).** |
@@ -139,9 +137,7 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 >                                 hist_exog_list:Optional[list[str]]=None,
 >                                 date_features:Union[bool,list[str]]=False,
 >                                 date_features_to_one_hot:Union[bool,list[s
->                                 tr]]=False, model:Literal['azureai','timeg
->                                 pt-1','timegpt-1-long-
->                                 horizon']='timegpt-1', num_partitions:Opti
+>                                 tr]]=False, model:str='timegpt-2.1', num_partitions:Opti
 >                                 onal[Annotated[int,Gt(gt=0)]]=None)
 > ```
 
@@ -162,14 +158,14 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 | step_size | Optional | None | Step size between each cross validation window. If None it will be equal to `h`. |
 | finetune_steps | Annotated | 0 | Number of steps used to finetune TimeGPT in the<br/>new data. |
 | finetune_depth | Literal | 1 | The depth of the finetuning. Uses a scale from 1 to 5, where 1 means little finetuning,<br/>and 5 means that the entire model is finetuned. |
-| finetune_loss | Literal | default | Loss function to use for finetuning. Options are: `default`, `mae`, `mse`, `rmse`, `mape`, and `smape`. |
+| finetune_loss | Literal | default | Loss function to use for finetuning. Options are: `default`, `mae`, `mse`, `rmse`, `mape`, `smape`, and `poisson`. |
 | finetuned_model_id | Optional | None | ID of previously fine-tuned model to use. |
 | refit | bool | True | Fine-tune the model in each window. If `False`, only fine-tunes on the first window.<br/>Only used if `finetune_steps` \> 0. |
 | clean_ex_first | bool | True | Clean exogenous signal before making forecasts using TimeGPT. |
 | hist_exog_list | Optional | None | Column names of the historical exogenous features. |
 | date_features | Union | False | Features computed from the dates.<br/>Can be pandas date attributes or functions that will take the dates as input.<br/>If True automatically adds most used date features for the<br/>frequency of `df`. |
 | date_features_to_one_hot | Union | False | Apply one-hot encoding to these date features.<br/>If `date_features=True`, then all date features are<br/>one-hot encoded by default. |
-| model | Literal | timegpt-1 | Model to use as a string. Options are: `timegpt-1`, and `timegpt-1-long-horizon`.<br/>We recommend using `timegpt-1-long-horizon` for forecasting<br/>if you want to predict more than one seasonal<br/>period given the frequency of your data. |
+| model | str | timegpt-2.1 | Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`,<br/>and the TimeGPT-2 family (e.g. `timegpt-2.1`, requires an eligible paid plan).<br/>Use `timegpt-1-long-horizon` to predict more than one seasonal<br/>period given the frequency of your data. |
 | num_partitions | Optional | None | Number of partitions to use.<br/>If None, the number of partitions will be equal<br/>to the available parallel resources in distributed environments. |
 | **Returns** | **AnyDFType** |  | **DataFrame with cross validation forecasts.** |
 
@@ -193,9 +189,7 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 >                                 validate_api_key:bool=False,
 >                                 date_features:Union[bool,list[str]]=False,
 >                                 date_features_to_one_hot:Union[bool,list[s
->                                 tr]]=False, model:Literal['azureai','timeg
->                                 pt-1','timegpt-1-long-
->                                 horizon']='timegpt-1', num_partitions:Opti
+>                                 tr]]=False, model:str='timegpt-2.1', num_partitions:Opti
 >                                 onal[Annotated[int,Gt(gt=0)]]=None)
 > ```
 
@@ -214,7 +208,7 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 | validate_api_key | bool | False | If True, validates api_key before sending requests. |
 | date_features | Union | False | Features computed from the dates.<br/>Can be pandas date attributes or functions that will take the dates as input.<br/>If True automatically adds most used date features for the<br/>frequency of `df`. |
 | date_features_to_one_hot | Union | False | Apply one-hot encoding to these date features.<br/>If `date_features=True`, then all date features are<br/>one-hot encoded by default. |
-| model | Literal | timegpt-1 | Model to use as a string. Options are: `timegpt-1`, and `timegpt-1-long-horizon`.<br/>We recommend using `timegpt-1-long-horizon` for forecasting<br/>if you want to predict more than one seasonal<br/>period given the frequency of your data. |
+| model | str | timegpt-2.1 | Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`,<br/>and the TimeGPT-2 family (e.g. `timegpt-2.1`, requires an eligible paid plan).<br/>Use `timegpt-1-long-horizon` to predict more than one seasonal<br/>period given the frequency of your data. |
 | num_partitions | Optional | None | Number of partitions to use.<br/>If None, the number of partitions will be equal<br/>to the available parallel resources in distributed environments. |
 | **Returns** | **AnyDFType** |  | **DataFrame with anomalies flagged by TimeGPT.** |
 
@@ -249,11 +243,10 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 >                         target_col:str='y',
 >                         finetune_steps:typing.Annotated[int,Ge(ge=0)]=10,
 >                         finetune_depth:Literal[1,2,3,4,5]=1, finetune_loss
->                         :Literal['default','mae','mse','rmse','mape','smap
->                         e']='default', output_model_id:Optional[str]=None,
->                         finetuned_model_id:Optional[str]=None, model:Liter
->                         al['azureai','timegpt-1','timegpt-1-long-
->                         horizon']='timegpt-1')
+>                         :Literal['default','mae','mse','rmse','mape',
+>                         'smape','poisson']='default', output_model_id:Optional[str]=None,
+>                         finetuned_model_id:Optional[str]=None,
+>                         model:str='timegpt-2.1')
 > ```
 
 *Fine-tune TimeGPT to your series.*
@@ -267,10 +260,10 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 | target_col | str | y | Column that contains the target. |
 | finetune_steps | Annotated | 10 | Number of steps used to finetune learning TimeGPT in the new data. |
 | finetune_depth | Literal | 1 | The depth of the finetuning. Uses a scale from 1 to 5, where 1 means little finetuning,<br/>and 5 means that the entire model is finetuned. |
-| finetune_loss | Literal | default | Loss function to use for finetuning. Options are: `default`, `mae`, `mse`, `rmse`, `mape`, and `smape`. |
+| finetune_loss | Literal | default | Loss function to use for finetuning. Options are: `default`, `mae`, `mse`, `rmse`, `mape`, `smape`, and `poisson`. |
 | output_model_id | Optional | None | ID to assign to the fine-tuned model. If `None`, an UUID is used. |
 | finetuned_model_id | Optional | None | ID of previously fine-tuned model to use as base. |
-| model | Literal | timegpt-1 | Model to use as a string. Options are: `timegpt-1`, and `timegpt-1-long-horizon`.<br/>We recommend using `timegpt-1-long-horizon` for forecasting<br/>if you want to predict more than one seasonal<br/>period given the frequency of your data. |
+| model | str | timegpt-2.1 | Model to use as a string. Options include `timegpt-1`, `timegpt-1-long-horizon`,<br/>and the TimeGPT-2 family (e.g. `timegpt-2.1`, requires an eligible paid plan).<br/>Use `timegpt-1-long-horizon` to predict more than one seasonal<br/>period given the frequency of your data. |
 | **Returns** | **str** |  | **ID of the fine-tuned model** |
 
 ------------------------------------------------------------------------

--- a/timegpt-docs/setup/azureai.mdx
+++ b/timegpt-docs/setup/azureai.mdx
@@ -65,7 +65,7 @@ icon: "rocket"
     ```
   </Step>
   <Step title="Step 4: Load your time series data">
-    In this example, we'll use the classic **AirPassengers** dataset to demonstrate forecasting. The dataset shows monthly passenger counts in Australia between 1949 and 1960.
+    In this example, we'll use the classic **AirPassengers** dataset to demonstrate forecasting. The dataset shows monthly totals of international airline passengers between 1949 and 1960.
 
     ```python Load AirPassengers dataset
     import pandas as pd
@@ -153,6 +153,11 @@ icon: "rocket"
     | 2 | 1961-03-01 | 463.116547 |
     | 3 | 1961-04-01 | 478.244507 |
     | 4 | 1961-05-01 | 505.646484 |
+
+    <Note>
+      The forecast column is always named `TimeGPT`, regardless of which model
+      you requested — including TimeGEN-1 on Azure.
+    </Note>
 
     Visualize the forecast results:
 


### PR DESCRIPTION
## Summary

This PR fixes documentation inaccuracies found during a docs audit. Every fix was verified against one of: the live API (`api.nixtla.io`, tested 2026-08-21), the SDK source in this repo (v0.8.0), or a link check. No behavioral code changes — docs, OpenAPI spec, and README only.

### REST examples (`introduction/faq.mdx`)
- The only REST example in the docs (duplicated in two accordions) used a nonexistent path (`/timegpt` → 404), an unaccepted auth header (`x-api-key` → 401), and a body field that doesn't exist in the schema (`df`). Replaced both with a call tested live against the API: `POST /v2/forecast` + `Authorization: Bearer` + `{"model", "series": {"y", "sizes"}, "freq", "h"}`.

### Python examples that raise TypeError on SDK 0.8.0 (`introduction/faq.mdx`)
- `forecast(..., return_model=True)` and the pickle save/load workflow — neither exists in the SDK. Replaced with the real flow: `finetune()` returns a `finetuned_model_id` (stored server-side), reused via `forecast(..., finetuned_model_id=...)`.
- `cross_validation(df, h=7, k=3, test_size=7)` → the signature has `n_windows`/`step_size`, not `k`/`test_size`.

### Error documentation
- The FAQ documented a six-field 401 body (`{'code': 'A12', 'requestID': ...}`) the API does not return. Live, both invalid-auth variants return `{"detail": "..."}` — replaced with the verbatim bodies.
- `openapi.json` documented no error responses beyond 422 (two operations documented no failure at all). Added a shared 401 response (both live variants as examples) to every operation, a 403 model-not-in-plan response (live body) to the five model endpoints, and a verified 422 example to `/v2/forecast`. 429/5xx intentionally left out — could not capture live bodies.
- Added root-level `"security": [{"HTTPBearer": []}]`, matching the per-operation declarations, so spec tooling doesn't generate unauthenticated clients.

### OpenAPI spec descriptions
- `freq` claimed only `D`/`M`/`H`/`W` are available, while the spec's own finetune example and several doc pages use `MS`. Verified live that REST accepts `MS` directly; description now says pandas offset aliases and links the alias table.
- `hist_exog` said "zero-based indices of the exogenous features" without saying what they index into. Documented (from SDK source): indices into `series.X`, with the SDK serializing future-exogenous features first, then historical.
- The online anomaly detection description promised a `z_score` field that doesn't exist in `OnlineAnomalyOutput`; corrected to `anomaly_score`.
- `model` descriptions never mentioned the TimeGPT-2 family; they now do, note the paid-plan requirement, and note that the API currently requires the field explicitly (omitting it returns 422 despite the declared default).

### SDK reference (`reference/sdk_reference.mdx`)
- Page documented `model: Literal['azureai','timegpt-1','timegpt-1-long-horizon']`. Actual SDK 0.8.0: `model: str = 'timegpt-2.1'`. Updated all four signatures and option rows; removed `azureai` (no longer in the SDK); added `poisson` to the `finetune_loss` options (in the SDK's `_Loss` literal but missing from the docs).

### Broken links & content corrections
- Two FAQ links pointed at `nixtlaverse.nixtla.io/nixtla/nixtla_client.html` (404) → now point at the SDK reference page.
- The enterprise contact URL on the subscription and about pages contained a URL-encoded literal ellipsis (`%5B…%5D`) pasted mid-UUID, returning HTTP 400 → replaced with the working book-a-call link. The subscription page also pointed readers to the FAQ for pricing details the FAQ doesn't contain → now points to book-a-call.
- FAQ said polars is unsupported and that missing values are unsupported; both contradicted the SDK and the docs' own tutorials. Corrected (missing target values as `NaN`, timestamps must be continuous; polars needs explicit `freq`).
- README (rendered on PyPI): four documentation links used a retired path scheme and 404 — including API-key setup, step one for a new user. All four replaced with URLs verified to return 200.
- `setup/azureai.mdx`: AirPassengers is international airline passengers, not "passenger counts in Australia"; added a note that the output column is always named `TimeGPT` regardless of the requested model.
- Quickstart: added a version-floored install command and a note that it uses TimeGPT-1 (all plans) vs the TimeGPT-2 family (paid plans).
- Data requirements: documented `time_col`/`target_col`/`id_col` renaming right after the required-columns section, since many doc pages use `timestamp`/`value`.
- Two FAQ console-output blocks were fenced as ```python (fail to parse as Python) → ```text.

## Verification
- REST examples, error bodies (401/403/422), `freq="MS"`, and `validate_api_key` behavior tested live against `api.nixtla.io` on 2026-08-21.
- SDK claims checked against `nixtla/nixtla_client.py` at v0.8.0.
- All replacement URLs checked (200).
- `openapi.json` re-validated after editing: parses, and all `$ref`s resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)