### PR TITLE
feat: add execute_step support to NixtlaClient

### DIFF
--- a/nixtla/__init__.py
+++ b/nixtla/__init__.py
@@ -6,6 +6,7 @@ from .nixtla_client import (
     Job,
     JobStatus,
     NixtlaClient,
+    StepResult,
 )
 
 __version__ = version("nixtla")
@@ -16,4 +17,5 @@ __all__ = [
     "Job",
     "JobStatus",
     "NixtlaClient",
+    "StepResult",
 ]

--- a/nixtla/__init__.py
+++ b/nixtla/__init__.py
@@ -1,13 +1,14 @@
 from importlib.metadata import version
-from .nixtla_client import (
+
+from .async_job import (
     AsyncJobCancelledError,
     AsyncJobError,
     AsyncJobTimeoutError,
     Job,
     JobStatus,
-    NixtlaClient,
-    StepResult,
 )
+from .nixtla_client import NixtlaClient
+from .steps import StepResult, ref
 
 __version__ = version("nixtla")
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "JobStatus",
     "NixtlaClient",
     "StepResult",
+    "ref",
 ]

--- a/nixtla/async_job.py
+++ b/nixtla/async_job.py
@@ -72,14 +72,15 @@ class Job:
         client: "NixtlaClient",
         job_id: str,
         endpoint: str,
-        get_result: Callable[[dict[str, Any]], Any],
+        get_result: Callable[[dict[str, Any], float, float], Any],
     ):
         """
         Args:
-            get_result: Builds the job's result from the terminal job-status response.
-                Tasks whose result is JSON read it out of that response's `result` field;
-                tasks whose result is binary (`execute_step` returns a zip) leave `result`
-                null there and fetch the payload from their own endpoint instead.
+            get_result: Builds the job's result, called as
+                `get_result(job_data, poll_interval, poll_timeout)`. Tasks whose result is JSON
+                read it out of the job-status response's `result` field and ignore the poll
+                settings; tasks whose result is binary (`execute_step` returns a zip) leave
+                `result` null there and use them to poll their own result endpoint.
         """
         self.job_id = job_id
         self.result: Any = None
@@ -147,10 +148,9 @@ class Job:
                 keeps running server-side until its own deadline.
 
         Note:
-            `poll_timeout` bounds the status polling only. A task whose result
-            is fetched separately (`execute_step`) then spends up to
-            `max_retries` attempts `retry_interval` apart retrieving it, on
-            top of `poll_timeout`.
+            A task whose result is fetched separately (`execute_step`) polls
+            for it after the status turns terminal, using these same settings
+            again -- so the total wait can reach twice `poll_timeout`.
         """
         with self._client._make_client(**self._client._client_kwargs) as http_client:
             try:
@@ -167,7 +167,7 @@ class Job:
                 raise
         # `_poll_job` returns only on success; every other terminal state raises.
         self._status = JobStatus.SUCCEEDED
-        self.result = self._get_result(job_data)
+        self.result = self._get_result(job_data, poll_interval, poll_timeout)
         return self.result
 
     def cancel(self) -> None:

--- a/nixtla/async_job.py
+++ b/nixtla/async_job.py
@@ -1,11 +1,8 @@
-import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 if TYPE_CHECKING:
     from .nixtla_client import NixtlaClient
-
-logger = logging.getLogger(__name__)
 
 
 class JobStatus(str, Enum):
@@ -113,7 +110,12 @@ class Job:
             self._status = status
         return status
 
-    def wait(self, poll_interval: float = 15, poll_timeout: float = 3600) -> Any:
+    def wait(
+        self,
+        poll_interval: float = 15,
+        poll_timeout: float = 3600,
+        cancel_on_timeout: bool = False,
+    ) -> Any:
         """Poll the job until it reaches a terminal state and return its result.
 
         Args:
@@ -122,6 +124,13 @@ class Job:
             poll_timeout (float): Maximum seconds to wait for the job to
                 reach a terminal state before raising `AsyncJobTimeoutError`.
                 Defaults to 3600.
+            cancel_on_timeout (bool): Whether to request cancellation of the
+                job when `poll_timeout` elapses. Defaults to False, so that
+                polling in short increments (calling `wait()` again to resume)
+                leaves the job running. Set to True to stop the job from
+                consuming server-side compute once you have given up on it.
+                Cancellation is best-effort: if the request fails it is logged
+                as a warning and `AsyncJobTimeoutError` is raised regardless.
 
         Returns:
             The job's parsed result (a DataFrame for forecast/cross_validation
@@ -133,12 +142,23 @@ class Job:
             AsyncJobCancelledError: If the job reaches the `"cancelled"`
                 terminal state (e.g. after a successful `cancel()`).
             AsyncJobTimeoutError: If `poll_timeout` elapses before the job
-                reaches a terminal state.
+                reaches a terminal state. `poll_timeout` only bounds the
+                client's polling, so unless `cancel_on_timeout` is set the job
+                keeps running server-side until its own deadline.
         """
         with self._client._make_client(**self._client._client_kwargs) as http_client:
-            job_data = self._client._poll_job(
-                http_client, self._endpoint, self.job_id, poll_interval, poll_timeout
-            )
+            try:
+                job_data = self._client._poll_job(
+                    http_client,
+                    self._endpoint,
+                    self.job_id,
+                    poll_interval,
+                    poll_timeout,
+                )
+            except AsyncJobTimeoutError:
+                if cancel_on_timeout:
+                    self._cancel_best_effort("client poll timeout")
+                raise
         # `_poll_job` returns only on success; every other terminal state raises.
         self._status = JobStatus.SUCCEEDED
         self.result = self._get_result(job_data)
@@ -150,6 +170,18 @@ class Job:
             self._client._cancel_job(http_client, self.job_id)
         self._status = JobStatus.CANCELLED
 
+    def _cancel_best_effort(self, reason: str) -> None:
+        """Request cancellation without letting a failure mask the exception
+        that is already propagating.
+
+        `_status` is only marked terminal when the server accepted the request,
+        so after a failed cancel `status` re-queries instead of reporting an
+        optimistic `"cancelled"`.
+        """
+        with self._client._make_client(**self._client._client_kwargs) as http_client:
+            if self._client._cancel_job_best_effort(http_client, self.job_id, reason):
+                self._status = JobStatus.CANCELLED
+
     def __enter__(self) -> "Job":
         return self
 
@@ -158,11 +190,4 @@ class Job:
             return
         if self._status is not None and self._status.is_terminal:
             return
-        try:
-            self.cancel()
-        except Exception:
-            logger.warning(
-                "Failed to cancel job %s during exception cleanup",
-                self.job_id,
-                exc_info=True,
-            )
+        self._cancel_best_effort("exception cleanup")

--- a/nixtla/async_job.py
+++ b/nixtla/async_job.py
@@ -75,25 +75,21 @@ class Job:
         client: "NixtlaClient",
         job_id: str,
         endpoint: str,
-        parse_result: Callable[..., Any],
-        fetch_result: Optional[Callable[[str], Any]] = None,
+        get_result: Callable[[dict[str, Any]], Any],
     ):
         """
         Args:
-            parse_result: Builds the result from the `result` field of the job-status
-                response, for tasks whose result is JSON.
-            fetch_result: Alternative used by tasks whose result is not JSON and so cannot
-                be inlined into the status response (`execute_step` returns a zip). When
-                given, `wait()` calls this with the job id instead of `parse_result`, and
-                it is responsible for retrieving the result itself.
+            get_result: Builds the job's result from the terminal job-status response.
+                Tasks whose result is JSON read it out of that response's `result` field;
+                tasks whose result is binary (`execute_step` returns a zip) leave `result`
+                null there and fetch the payload from their own endpoint instead.
         """
         self.job_id = job_id
         self.result: Any = None
         self._status: Optional[JobStatus] = None
         self._client = client
         self._endpoint = endpoint
-        self._parse_result = parse_result
-        self._fetch_result = fetch_result
+        self._get_result = get_result
 
     @property
     def status(self) -> JobStatus:
@@ -143,13 +139,9 @@ class Job:
             job_data = self._client._poll_job(
                 http_client, self._endpoint, self.job_id, poll_interval, poll_timeout
             )
-        self._status = JobStatus(job_data["status"])
-        if self._fetch_result is not None:
-            # Binary tasks leave `result` null in the status response and serve the payload
-            # from their own endpoint, so the result is fetched rather than parsed.
-            self.result = self._fetch_result(self.job_id)
-        else:
-            self.result = self._parse_result(job_data["result"])
+        # `_poll_job` returns only on success; every other terminal state raises.
+        self._status = JobStatus.SUCCEEDED
+        self.result = self._get_result(job_data)
         return self.result
 
     def cancel(self) -> None:

--- a/nixtla/async_job.py
+++ b/nixtla/async_job.py
@@ -114,7 +114,7 @@ class Job:
         self,
         poll_interval: float = 15,
         poll_timeout: float = 3600,
-        cancel_on_timeout: bool = False,
+        cancel_on_timeout: bool = True,
     ) -> Any:
         """Poll the job until it reaches a terminal state and return its result.
 
@@ -125,10 +125,10 @@ class Job:
                 reach a terminal state before raising `AsyncJobTimeoutError`.
                 Defaults to 3600.
             cancel_on_timeout (bool): Whether to request cancellation of the
-                job when `poll_timeout` elapses. Defaults to False, so that
-                polling in short increments (calling `wait()` again to resume)
-                leaves the job running. Set to True to stop the job from
-                consuming server-side compute once you have given up on it.
+                job when `poll_timeout` elapses. Defaults to True, so that a
+                job you have given up on stops consuming server-side compute.
+                Set to False to poll in short increments -- calling `wait()`
+                again to resume -- which requires the job to still be running.
                 Cancellation is best-effort: if the request fails it is logged
                 as a warning and `AsyncJobTimeoutError` is raised regardless.
 
@@ -143,7 +143,7 @@ class Job:
                 terminal state (e.g. after a successful `cancel()`).
             AsyncJobTimeoutError: If `poll_timeout` elapses before the job
                 reaches a terminal state. `poll_timeout` only bounds the
-                client's polling, so unless `cancel_on_timeout` is set the job
+                client's polling, so with `cancel_on_timeout=False` the job
                 keeps running server-side until its own deadline.
 
         Note:

--- a/nixtla/async_job.py
+++ b/nixtla/async_job.py
@@ -148,8 +148,9 @@ class Job:
 
         Note:
             `poll_timeout` bounds the status polling only. A task whose result
-            is fetched separately (`execute_step`) then spends up to the
-            client's `max_wait_time` retrieving it, on top of `poll_timeout`.
+            is fetched separately (`execute_step`) then spends up to
+            `max_retries` attempts `retry_interval` apart retrieving it, on
+            top of `poll_timeout`.
         """
         with self._client._make_client(**self._client._client_kwargs) as http_client:
             try:

--- a/nixtla/async_job.py
+++ b/nixtla/async_job.py
@@ -57,7 +57,8 @@ class AsyncJobCancelledError(Exception):
 
 class Job:
     """Handle to a server-side async job submitted via `submit_forecast_job`,
-    `submit_finetune_job`, or `submit_cross_validation_job`.
+    `submit_finetune_job`, `submit_cross_validation_job`, or
+    `submit_execute_step_job`.
 
     `status` queries the server for the job's current status; call `wait()`
     to block until it reaches a terminal state and get its result, or
@@ -75,13 +76,24 @@ class Job:
         job_id: str,
         endpoint: str,
         parse_result: Callable[..., Any],
+        fetch_result: Optional[Callable[[str], Any]] = None,
     ):
+        """
+        Args:
+            parse_result: Builds the result from the `result` field of the job-status
+                response, for tasks whose result is JSON.
+            fetch_result: Alternative used by tasks whose result is not JSON and so cannot
+                be inlined into the status response (`execute_step` returns a zip). When
+                given, `wait()` calls this with the job id instead of `parse_result`, and
+                it is responsible for retrieving the result itself.
+        """
         self.job_id = job_id
         self.result: Any = None
         self._status: Optional[JobStatus] = None
         self._client = client
         self._endpoint = endpoint
         self._parse_result = parse_result
+        self._fetch_result = fetch_result
 
     @property
     def status(self) -> JobStatus:
@@ -117,7 +129,8 @@ class Job:
 
         Returns:
             The job's parsed result (a DataFrame for forecast/cross_validation
-            jobs, a fine-tuned model id string for finetune jobs).
+            jobs, a fine-tuned model id string for finetune jobs, a `StepResult`
+            for execute_step jobs).
 
         Raises:
             AsyncJobError: If the job fails server-side.
@@ -131,7 +144,12 @@ class Job:
                 http_client, self._endpoint, self.job_id, poll_interval, poll_timeout
             )
         self._status = JobStatus(job_data["status"])
-        self.result = self._parse_result(job_data["result"])
+        if self._fetch_result is not None:
+            # Binary tasks leave `result` null in the status response and serve the payload
+            # from their own endpoint, so the result is fetched rather than parsed.
+            self.result = self._fetch_result(self.job_id)
+        else:
+            self.result = self._parse_result(job_data["result"])
         return self.result
 
     def cancel(self) -> None:

--- a/nixtla/async_job.py
+++ b/nixtla/async_job.py
@@ -145,6 +145,11 @@ class Job:
                 reaches a terminal state. `poll_timeout` only bounds the
                 client's polling, so unless `cancel_on_timeout` is set the job
                 keeps running server-side until its own deadline.
+
+        Note:
+            `poll_timeout` bounds the status polling only. A task whose result
+            is fetched separately (`execute_step`) then spends up to the
+            client's `max_wait_time` retrieving it, on top of `poll_timeout`.
         """
         with self._client._make_client(**self._client._client_kwargs) as http_client:
             try:

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -246,9 +246,9 @@ def _is_retriable_error(exc: Exception) -> bool:
     retriable_codes = [
         HTTPStatus.REQUEST_TIMEOUT,
         # A binary job's result endpoint answers 202 while the zip has not materialized yet, so
-        # "not ready" means poll again rather than give up. 409 stays listed because older servers
-        # used it for that same case; on current ones it means the job ended without a result, and
-        # retrying is merely wasteful rather than wrong.
+        # "not ready" means poll again rather than give up. 409 is listed alongside it for
+        # compatibility; where it instead means the job ended without a result, retrying is
+        # merely wasteful rather than wrong.
         HTTPStatus.ACCEPTED,
         HTTPStatus.CONFLICT,
         HTTPStatus.TOO_MANY_REQUESTS,
@@ -1407,9 +1407,9 @@ class NixtlaClient:
         """Fetch a binary job's result from its dedicated endpoint.
 
         Binary results cannot be inlined into the JSON status response, so they are served
-        separately. The server answers 202 while the job has not yet succeeded (older servers
-        answered 409), and `_is_retriable_error` treats both as retriable -- callers should go
-        through `_retry_strategy` so that race resolves itself rather than surfacing.
+        separately. The API answers 202 while the job has not yet succeeded, and 409 is treated
+        the same way; `_is_retriable_error` covers both -- callers should go through
+        `_retry_strategy` so that race resolves itself rather than surfacing.
 
         The status check stays exact: anything other than 200 raises rather than returning a
         body, so a "not ready" JSON payload is never mistaken for the zip.
@@ -4055,9 +4055,9 @@ class NixtlaClient:
     ) -> Job:
         """Submit a single TSMP step to run asynchronously.
 
-        `execute_step` runs one TSMP top-level API call server-side in a
-        fresh sandbox: nothing is registered and nothing is cached between
-        calls, so every request is self-contained and carries its own data.
+        `execute_step` runs one TSMP top-level API call server-side. Each
+        call is independent: no state carries over from one to the next, so
+        every request is self-contained and carries its own data.
         This does not block; it submits the job and immediately returns a
         `Job` handle. Call `job.wait()` to poll until it completes and get a
         `StepResult`, or `job.cancel()` to request that the server stop it.
@@ -4086,11 +4086,11 @@ class NixtlaClient:
         `step.to_pandas()`.
 
         There is no `model` argument: a step names the models it runs inside
-        `params`, and the sandbox reaches them over the API rather than from
-        a checkpoint local to one host.
+        `params`.
 
-        Not reachable over this transport: `train` and `optimize_model`.
-        Both require a `tune.Space`, which has no JSON encoding.
+        Not reachable over this transport: `optimize_model`, which requires a
+        `tune.Space` that has no JSON encoding. A pandas index is never sent
+        as data; a named one is folded into a column, anything else dropped.
 
         Args:
             func_name (str): TSMP top-level API to run, e.g. `'forecast'`,
@@ -4115,9 +4115,12 @@ class NixtlaClient:
             TypeError: If a `data` value is not a pyarrow Table or an eager
                 pandas/polars DataFrame.
             ValueError: If a `ref` names a table that `data` does not supply,
-                a `data` key is not a bare name, or the encoded metadata
-                exceeds the header budget. All are raised locally, before
-                anything is uploaded.
+                a `ref` envelope nests another `ref` (the server would ignore
+                it), a `data` key is not a bare name, `func_name` is empty or
+                over 128 characters, `job_timeout_seconds` is not positive, or
+                the request is over one of the server's budgets (metadata
+                header size or nesting, table count, body size). All are
+                raised locally, before anything is uploaded.
 
         Returns:
             Job: Handle to the submitted job. `job.wait()` returns a `StepResult` with `.data`

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -1419,6 +1419,14 @@ class NixtlaClient:
             )
         if resp.status_code not in (HTTPStatus.OK, HTTPStatus.ACCEPTED):
             raise ApiError(status_code=resp.status_code, body=resp_body)
+        # Same envelope unwrap `_make_request` applies, so a wrapped body doesn't become a KeyError.
+        if "data" in resp_body:
+            resp_body = resp_body["data"]
+        if "job_id" not in resp_body:
+            raise ApiError(
+                status_code=resp.status_code,
+                body=f"Response has no job_id: {resp_body}",
+            )
         return resp_body["job_id"]
 
     def _get_job_result_bytes(
@@ -2063,7 +2071,7 @@ class NixtlaClient:
         feature_contributions: bool,
         model_parameters: _ExtraParamDataType,
         multivariate: bool,
-        job_timeout_seconds: Optional[int] = None,
+        _job_timeout_seconds: Optional[int] = None,
         # Internal-only params used for the num_partitions/distributed async
         # fan-out; not part of the public API. NOTE: when _is_async_job=True,
         # each Fugue partition submits and polls its own async job
@@ -2137,7 +2145,7 @@ class NixtlaClient:
                 feature_contributions=feature_contributions,
                 model_parameters=model_parameters,
                 multivariate=multivariate,
-                job_timeout_seconds=job_timeout_seconds,
+                _job_timeout_seconds=_job_timeout_seconds,
                 _is_async_job=_is_async_job,
                 _poll_interval=_poll_interval,
                 _poll_timeout=_poll_timeout,
@@ -2435,12 +2443,14 @@ class NixtlaClient:
         feature_contributions: bool = False,
         model_parameters: _ExtraParamDataType = None,
         multivariate: bool = False,
-        job_timeout_seconds: Optional[int] = None,
         # Internal-only params used by the num_partitions/distributed async fan-out.
         *,
         _is_async_job: bool = False,
         _poll_interval: float = 15,
         _poll_timeout: float = 3600,
+        # Per-job server-side time limit, applied to each job this call submits. Only valid with
+        # _is_async_job.
+        _job_timeout_seconds: Optional[int] = None,
     ) -> AnyDFType:
         """Forecast your time series using TimeGPT.
 
@@ -2535,18 +2545,6 @@ class NixtlaClient:
             multivariate (bool): If True, enables multivariate predictions.
                 Defaults to False. Note: multivariate predictions are only
                 supported for a select set of TimeGPT models.
-            job_timeout_seconds (int, optional): Maximum seconds the server
-                allows each async job this call submits to run before
-                terminating it server-side. Only meaningful when this call
-                runs its work as async jobs; passing it otherwise raises
-                `ValueError`, since a synchronous request creates no job.
-                The budget is per job, not per call: with `num_partitions=N`
-                every partition is its own job and each gets the full value,
-                and `add_history=True` submits a second job whose server-side
-                maximum may differ from the forecast one, so a value accepted
-                by one can be rejected (422) by the other. Distinct from
-                `NixtlaClient(timeout=...)`, which bounds a single HTTP
-                request. Defaults to the server's default for the task.
 
         Returns:
             pandas, polars, dask or spark DataFrame or ray Dataset:
@@ -2554,11 +2552,11 @@ class NixtlaClient:
                 probabilistic predictions (if level is not None).
         """
         extra_param_checker.validate_python(model_parameters)
-        _validate_job_timeout_seconds(job_timeout_seconds)
-        if job_timeout_seconds is not None and not _is_async_job:
+        _validate_job_timeout_seconds(_job_timeout_seconds)
+        if _job_timeout_seconds is not None and not _is_async_job:
             raise ValueError(
-                "job_timeout_seconds only applies when this call runs its work as async "
-                "jobs; a synchronous request creates no job for it to bound."
+                "_job_timeout_seconds requires _is_async_job; a synchronous request "
+                "creates no job for it to bound."
             )
 
         if not isinstance(df, (pd.DataFrame, pl_DataFrame)):
@@ -2588,7 +2586,7 @@ class NixtlaClient:
                 feature_contributions=feature_contributions,
                 model_parameters=model_parameters,
                 multivariate=multivariate,
-                job_timeout_seconds=job_timeout_seconds,
+                _job_timeout_seconds=_job_timeout_seconds,
                 _is_async_job=_is_async_job,
                 _poll_interval=_poll_interval,
                 _poll_timeout=_poll_timeout,
@@ -2633,7 +2631,7 @@ class NixtlaClient:
                         payload,
                         _poll_interval,
                         _poll_timeout,
-                        job_timeout_seconds=job_timeout_seconds,
+                        job_timeout_seconds=_job_timeout_seconds,
                     )
                 else:
                     resp = self._make_request_with_retries(
@@ -2658,7 +2656,7 @@ class NixtlaClient:
                             in_sample_payload,
                             _poll_interval,
                             _poll_timeout,
-                            job_timeout_seconds=job_timeout_seconds,
+                            job_timeout_seconds=_job_timeout_seconds,
                         )
                     else:
                         in_sample_resp = self._make_request_with_retries(
@@ -2676,7 +2674,7 @@ class NixtlaClient:
                     _is_async_job=_is_async_job,
                     _poll_interval=_poll_interval,
                     _poll_timeout=_poll_timeout,
-                    _job_timeout_seconds=job_timeout_seconds,
+                    _job_timeout_seconds=_job_timeout_seconds,
                 )
                 if add_history:
                     insample_h, n_windows = _get_in_sample_horizon_and_windows(
@@ -2698,7 +2696,7 @@ class NixtlaClient:
                         _is_async_job=_is_async_job,
                         _poll_interval=_poll_interval,
                         _poll_timeout=_poll_timeout,
-                        _job_timeout_seconds=job_timeout_seconds,
+                        _job_timeout_seconds=_job_timeout_seconds,
                     )
                     insample_feat_contributions = in_sample_resp.get(
                         "feature_contributions", None
@@ -3480,7 +3478,7 @@ class NixtlaClient:
         model_parameters: _ExtraParamDataType,
         multivariate: bool,
         categorical_exog_list: Optional[list[str]] = None,
-        job_timeout_seconds: Optional[int] = None,
+        _job_timeout_seconds: Optional[int] = None,
         # Internal-only params used for the num_partitions/distributed async
         # fan-out; not part of the public API. NOTE: when _is_async_job=True,
         # each Fugue partition submits and polls its own async job
@@ -3535,7 +3533,7 @@ class NixtlaClient:
                 model_parameters=model_parameters,
                 multivariate=multivariate,
                 categorical_exog_list=categorical_exog_list,
-                job_timeout_seconds=job_timeout_seconds,
+                _job_timeout_seconds=_job_timeout_seconds,
                 _is_async_job=_is_async_job,
                 _poll_interval=_poll_interval,
                 _poll_timeout=_poll_timeout,
@@ -3747,12 +3745,14 @@ class NixtlaClient:
         model_parameters: _ExtraParamDataType = None,
         multivariate: bool = False,
         categorical_exog_list: Optional[list[str]] = None,
-        job_timeout_seconds: Optional[int] = None,
         # Internal-only params used by the num_partitions/distributed async fan-out.
         *,
         _is_async_job: bool = False,
         _poll_interval: float = 15,
         _poll_timeout: float = 3600,
+        # Per-job server-side time limit, applied to each job this call submits. Only valid with
+        # _is_async_job.
+        _job_timeout_seconds: Optional[int] = None,
     ) -> AnyDFType:
         """Perform cross validation in your time series using TimeGPT.
 
@@ -3845,27 +3845,17 @@ class NixtlaClient:
             categorical_exog_list (list[str], optional): Column names of
                 categorical exogenous features in (can be strings or
                 numbers). Defaults to None.
-            job_timeout_seconds (int, optional): Maximum seconds the server
-                allows each async job this call submits to run before
-                terminating it server-side. Only meaningful when this call
-                runs its work as async jobs; passing it otherwise raises
-                `ValueError`, since a synchronous request creates no job.
-                The budget is per job, not per call: with `num_partitions=N`
-                every partition is its own job and each gets the full value.
-                Distinct from `NixtlaClient(timeout=...)`, which bounds a
-                single HTTP request. Defaults to the server's default for
-                the task.
 
         Returns:
             pandas, polars, dask or spark DataFrame or ray Dataset:
                 DataFrame with cross validation forecasts.
         """
         extra_param_checker.validate_python(model_parameters)
-        _validate_job_timeout_seconds(job_timeout_seconds)
-        if job_timeout_seconds is not None and not _is_async_job:
+        _validate_job_timeout_seconds(_job_timeout_seconds)
+        if _job_timeout_seconds is not None and not _is_async_job:
             raise ValueError(
-                "job_timeout_seconds only applies when this call runs its work as async "
-                "jobs; a synchronous request creates no job for it to bound."
+                "_job_timeout_seconds requires _is_async_job; a synchronous request "
+                "creates no job for it to bound."
             )
         if not isinstance(df, (pd.DataFrame, pl_DataFrame)):
             return self._distributed_cross_validation(
@@ -3894,7 +3884,7 @@ class NixtlaClient:
                 model_parameters=model_parameters,
                 multivariate=multivariate,
                 categorical_exog_list=categorical_exog_list,
-                job_timeout_seconds=job_timeout_seconds,
+                _job_timeout_seconds=_job_timeout_seconds,
                 _is_async_job=_is_async_job,
                 _poll_interval=_poll_interval,
                 _poll_timeout=_poll_timeout,
@@ -3934,7 +3924,7 @@ class NixtlaClient:
                         payload,
                         _poll_interval,
                         _poll_timeout,
-                        job_timeout_seconds=job_timeout_seconds,
+                        job_timeout_seconds=_job_timeout_seconds,
                     )
                 else:
                     resp = self._make_request_with_retries(
@@ -3949,7 +3939,7 @@ class NixtlaClient:
                     _is_async_job=_is_async_job,
                     _poll_interval=_poll_interval,
                     _poll_timeout=_poll_timeout,
-                    _job_timeout_seconds=job_timeout_seconds,
+                    _job_timeout_seconds=_job_timeout_seconds,
                 )
 
         return parse_result(resp)
@@ -4577,10 +4567,10 @@ def _forecast_wrapper(
     feature_contributions: bool,
     model_parameters: _ExtraParamDataType,
     multivariate: bool,
-    job_timeout_seconds: Optional[int] = None,
     _is_async_job: bool = False,
     _poll_interval: float = 15,
     _poll_timeout: float = 3600,
+    _job_timeout_seconds: Optional[int] = None,
 ) -> pd.DataFrame:
     if "_in_sample" in df:
         in_sample_mask = df["_in_sample"]
@@ -4614,10 +4604,10 @@ def _forecast_wrapper(
         feature_contributions=feature_contributions,
         model_parameters=model_parameters,
         multivariate=multivariate,
-        job_timeout_seconds=job_timeout_seconds,
         _is_async_job=_is_async_job,
         _poll_interval=_poll_interval,
         _poll_timeout=_poll_timeout,
+        _job_timeout_seconds=_job_timeout_seconds,
     )
 
 
@@ -4734,10 +4724,10 @@ def _cross_validation_wrapper(
     model_parameters: _ExtraParamDataType,
     multivariate: bool,
     categorical_exog_list: Optional[list[str]] = None,
-    job_timeout_seconds: Optional[int] = None,
     _is_async_job: bool = False,
     _poll_interval: float = 15,
     _poll_timeout: float = 3600,
+    _job_timeout_seconds: Optional[int] = None,
 ) -> pd.DataFrame:
     return client.cross_validation(
         df=df,
@@ -4765,10 +4755,10 @@ def _cross_validation_wrapper(
         model_parameters=model_parameters,
         multivariate=multivariate,
         categorical_exog_list=categorical_exog_list,
-        job_timeout_seconds=job_timeout_seconds,
         _is_async_job=_is_async_job,
         _poll_interval=_poll_interval,
         _poll_timeout=_poll_timeout,
+        _job_timeout_seconds=_job_timeout_seconds,
     )
 
 

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -1390,9 +1390,9 @@ class NixtlaClient:
             client=self,
             job_id=job_id,
             endpoint=endpoint,
-            # A JSON result is inline in the status response, so there is nothing to wait for
-            # and the poll settings are unused.
-            get_result=lambda job_data, poll_interval, poll_timeout: parse_result(
+            # A JSON result is inline in the status response, so there is nothing to wait
+            # for: the poll settings `Job` passes are accepted and ignored.
+            get_result=lambda job_data, *_poll_settings: parse_result(
                 job_data["result"]
             ),
         )
@@ -1443,8 +1443,11 @@ class NixtlaClient:
         """Fetch a binary job's result from its dedicated endpoint, once.
 
         Binary results cannot be inlined into the JSON status response, so they are served
-        separately. Callers go through `_wait_for_job_result_bytes`, which handles the
-        not-ready answer this can raise.
+        separately. A succeeded job's result is not served the instant its status says so:
+        until it is ready the endpoint answers with one of `_RESULT_NOT_READY_CODES`, which
+        this method raises as an `ApiError` like any other non-200. Call
+        `_wait_for_job_result_bytes` rather than this directly -- it recognises those codes
+        as "still being assembled" and keeps polling, instead of reporting a failure.
 
         The status check stays exact: anything other than 200 raises rather than returning a
         body, so a "not ready" JSON payload is never mistaken for the zip.
@@ -4178,15 +4181,17 @@ class NixtlaClient:
         back in as the next step's `data`, calls chain without any file or
         byte handling::
 
-            from nixtla import ref
+            from nixtla import NixtlaClient, ref
 
-            step1 = nc.submit_execute_step_job(
+            nixtla_client = NixtlaClient()
+
+            step1 = nixtla_client.submit_execute_step_job(
                 "make_forecast_input",
                 {"data": ref("panel"), "freq": "D"},
                 data={"panel": df},
             ).wait()
 
-            step2 = nc.submit_execute_step_job(
+            step2 = nixtla_client.submit_execute_step_job(
                 "forecast",
                 {"resource": ref("result"), "models": ["timegpt-1"], "h": 7},
                 data=step1.data,

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -261,6 +261,31 @@ def _is_retriable_error(exc: Exception) -> bool:
     )
 
 
+def _validate_job_timeout_seconds(job_timeout_seconds: Optional[int]) -> None:
+    """Reject a job timeout the server would refuse, before spending a round-trip on it.
+
+    Kept identical in wording to the check `steps.build_request` runs for `execute_step`, which
+    validates separately because that module is a self-contained codec.
+    """
+    if job_timeout_seconds is not None and job_timeout_seconds <= 0:
+        raise ValueError(
+            f"job_timeout_seconds must be positive, got {job_timeout_seconds!r}"
+        )
+
+
+def _with_job_options(
+    payload: dict[str, Any], job_timeout_seconds: Optional[int]
+) -> dict[str, Any]:
+    """Return `payload` carrying the job's server-side timeout, or unchanged when none is set.
+
+    Never mutates the argument: `forecast` reuses one payload to derive its add_history request,
+    and the partitioned path hands the same dict shape to several jobs.
+    """
+    if job_timeout_seconds is None:
+        return payload
+    return {**payload, "job_options": {"timeout_seconds": job_timeout_seconds}}
+
+
 def _retry_strategy(max_retries: int, retry_interval: int, max_wait_time: int):
     def after_retry(retry_state: RetryCallState) -> None:
         error = retry_state.outcome.exception()
@@ -1303,7 +1328,9 @@ class NixtlaClient:
         poll_interval: float,
         poll_timeout: float,
         multithreaded_compress: bool = True,
+        job_timeout_seconds: Optional[int] = None,
     ) -> dict[str, Any]:
+        payload = _with_job_options(payload, job_timeout_seconds)
         job_id = self._submit_job(client, endpoint, payload, multithreaded_compress)
         try:
             job_data = self._poll_job(
@@ -1354,12 +1381,8 @@ class NixtlaClient:
         job_timeout_seconds: Optional[int],
         parse_result: Callable[..., Any],
     ) -> Job:
-        if job_timeout_seconds is not None:
-            # Don't mutate the caller's dict: `forecast` reuses its payload for add_history.
-            payload = {
-                **payload,
-                "job_options": {"timeout_seconds": job_timeout_seconds},
-            }
+        _validate_job_timeout_seconds(job_timeout_seconds)
+        payload = _with_job_options(payload, job_timeout_seconds)
         with self._make_client(**self._client_kwargs) as client:
             job_id = self._submit_job(client, endpoint, payload)
         return Job(
@@ -1459,6 +1482,7 @@ class NixtlaClient:
         _is_async_job: bool = False,
         _poll_interval: float = 15,
         _poll_timeout: float = 3600,
+        _job_timeout_seconds: Optional[int] = None,
     ) -> dict[str, Any]:
         from tqdm.auto import tqdm
 
@@ -1481,6 +1505,7 @@ class NixtlaClient:
                         poll_interval=_poll_interval,
                         poll_timeout=_poll_timeout,
                         multithreaded_compress=False,
+                        job_timeout_seconds=_job_timeout_seconds,
                     ): i
                     for i, payload in enumerate(payloads)
                 }
@@ -2038,6 +2063,7 @@ class NixtlaClient:
         feature_contributions: bool,
         model_parameters: _ExtraParamDataType,
         multivariate: bool,
+        job_timeout_seconds: Optional[int] = None,
         # Internal-only params used for the num_partitions/distributed async
         # fan-out; not part of the public API. NOTE: when _is_async_job=True,
         # each Fugue partition submits and polls its own async job
@@ -2111,6 +2137,7 @@ class NixtlaClient:
                 feature_contributions=feature_contributions,
                 model_parameters=model_parameters,
                 multivariate=multivariate,
+                job_timeout_seconds=job_timeout_seconds,
                 _is_async_job=_is_async_job,
                 _poll_interval=_poll_interval,
                 _poll_timeout=_poll_timeout,
@@ -2408,6 +2435,7 @@ class NixtlaClient:
         feature_contributions: bool = False,
         model_parameters: _ExtraParamDataType = None,
         multivariate: bool = False,
+        job_timeout_seconds: Optional[int] = None,
         # Internal-only params used by the num_partitions/distributed async fan-out.
         *,
         _is_async_job: bool = False,
@@ -2507,6 +2535,18 @@ class NixtlaClient:
             multivariate (bool): If True, enables multivariate predictions.
                 Defaults to False. Note: multivariate predictions are only
                 supported for a select set of TimeGPT models.
+            job_timeout_seconds (int, optional): Maximum seconds the server
+                allows each async job this call submits to run before
+                terminating it server-side. Only meaningful when this call
+                runs its work as async jobs; passing it otherwise raises
+                `ValueError`, since a synchronous request creates no job.
+                The budget is per job, not per call: with `num_partitions=N`
+                every partition is its own job and each gets the full value,
+                and `add_history=True` submits a second job whose server-side
+                maximum may differ from the forecast one, so a value accepted
+                by one can be rejected (422) by the other. Distinct from
+                `NixtlaClient(timeout=...)`, which bounds a single HTTP
+                request. Defaults to the server's default for the task.
 
         Returns:
             pandas, polars, dask or spark DataFrame or ray Dataset:
@@ -2514,6 +2554,12 @@ class NixtlaClient:
                 probabilistic predictions (if level is not None).
         """
         extra_param_checker.validate_python(model_parameters)
+        _validate_job_timeout_seconds(job_timeout_seconds)
+        if job_timeout_seconds is not None and not _is_async_job:
+            raise ValueError(
+                "job_timeout_seconds only applies when this call runs its work as async "
+                "jobs; a synchronous request creates no job for it to bound."
+            )
 
         if not isinstance(df, (pd.DataFrame, pl_DataFrame)):
             return self._distributed_forecast(
@@ -2542,6 +2588,7 @@ class NixtlaClient:
                 feature_contributions=feature_contributions,
                 model_parameters=model_parameters,
                 multivariate=multivariate,
+                job_timeout_seconds=job_timeout_seconds,
                 _is_async_job=_is_async_job,
                 _poll_interval=_poll_interval,
                 _poll_timeout=_poll_timeout,
@@ -2581,7 +2628,12 @@ class NixtlaClient:
             if num_partitions is None:
                 if _is_async_job:
                     resp = self._run_async_job(
-                        client, "v2/forecast", payload, _poll_interval, _poll_timeout
+                        client,
+                        "v2/forecast",
+                        payload,
+                        _poll_interval,
+                        _poll_timeout,
+                        job_timeout_seconds=job_timeout_seconds,
                     )
                 else:
                     resp = self._make_request_with_retries(
@@ -2606,6 +2658,7 @@ class NixtlaClient:
                             in_sample_payload,
                             _poll_interval,
                             _poll_timeout,
+                            job_timeout_seconds=job_timeout_seconds,
                         )
                     else:
                         in_sample_resp = self._make_request_with_retries(
@@ -2623,6 +2676,7 @@ class NixtlaClient:
                     _is_async_job=_is_async_job,
                     _poll_interval=_poll_interval,
                     _poll_timeout=_poll_timeout,
+                    _job_timeout_seconds=job_timeout_seconds,
                 )
                 if add_history:
                     insample_h, n_windows = _get_in_sample_horizon_and_windows(
@@ -2644,6 +2698,7 @@ class NixtlaClient:
                         _is_async_job=_is_async_job,
                         _poll_interval=_poll_interval,
                         _poll_timeout=_poll_timeout,
+                        _job_timeout_seconds=job_timeout_seconds,
                     )
                     insample_feat_contributions = in_sample_resp.get(
                         "feature_contributions", None
@@ -3425,6 +3480,7 @@ class NixtlaClient:
         model_parameters: _ExtraParamDataType,
         multivariate: bool,
         categorical_exog_list: Optional[list[str]] = None,
+        job_timeout_seconds: Optional[int] = None,
         # Internal-only params used for the num_partitions/distributed async
         # fan-out; not part of the public API. NOTE: when _is_async_job=True,
         # each Fugue partition submits and polls its own async job
@@ -3479,6 +3535,7 @@ class NixtlaClient:
                 model_parameters=model_parameters,
                 multivariate=multivariate,
                 categorical_exog_list=categorical_exog_list,
+                job_timeout_seconds=job_timeout_seconds,
                 _is_async_job=_is_async_job,
                 _poll_interval=_poll_interval,
                 _poll_timeout=_poll_timeout,
@@ -3690,6 +3747,7 @@ class NixtlaClient:
         model_parameters: _ExtraParamDataType = None,
         multivariate: bool = False,
         categorical_exog_list: Optional[list[str]] = None,
+        job_timeout_seconds: Optional[int] = None,
         # Internal-only params used by the num_partitions/distributed async fan-out.
         *,
         _is_async_job: bool = False,
@@ -3787,12 +3845,28 @@ class NixtlaClient:
             categorical_exog_list (list[str], optional): Column names of
                 categorical exogenous features in (can be strings or
                 numbers). Defaults to None.
+            job_timeout_seconds (int, optional): Maximum seconds the server
+                allows each async job this call submits to run before
+                terminating it server-side. Only meaningful when this call
+                runs its work as async jobs; passing it otherwise raises
+                `ValueError`, since a synchronous request creates no job.
+                The budget is per job, not per call: with `num_partitions=N`
+                every partition is its own job and each gets the full value.
+                Distinct from `NixtlaClient(timeout=...)`, which bounds a
+                single HTTP request. Defaults to the server's default for
+                the task.
 
         Returns:
             pandas, polars, dask or spark DataFrame or ray Dataset:
                 DataFrame with cross validation forecasts.
         """
         extra_param_checker.validate_python(model_parameters)
+        _validate_job_timeout_seconds(job_timeout_seconds)
+        if job_timeout_seconds is not None and not _is_async_job:
+            raise ValueError(
+                "job_timeout_seconds only applies when this call runs its work as async "
+                "jobs; a synchronous request creates no job for it to bound."
+            )
         if not isinstance(df, (pd.DataFrame, pl_DataFrame)):
             return self._distributed_cross_validation(
                 df=df,
@@ -3820,6 +3894,7 @@ class NixtlaClient:
                 model_parameters=model_parameters,
                 multivariate=multivariate,
                 categorical_exog_list=categorical_exog_list,
+                job_timeout_seconds=job_timeout_seconds,
                 _is_async_job=_is_async_job,
                 _poll_interval=_poll_interval,
                 _poll_timeout=_poll_timeout,
@@ -3859,6 +3934,7 @@ class NixtlaClient:
                         payload,
                         _poll_interval,
                         _poll_timeout,
+                        job_timeout_seconds=job_timeout_seconds,
                     )
                 else:
                     resp = self._make_request_with_retries(
@@ -3873,6 +3949,7 @@ class NixtlaClient:
                     _is_async_job=_is_async_job,
                     _poll_interval=_poll_interval,
                     _poll_timeout=_poll_timeout,
+                    _job_timeout_seconds=job_timeout_seconds,
                 )
 
         return parse_result(resp)
@@ -4500,6 +4577,7 @@ def _forecast_wrapper(
     feature_contributions: bool,
     model_parameters: _ExtraParamDataType,
     multivariate: bool,
+    job_timeout_seconds: Optional[int] = None,
     _is_async_job: bool = False,
     _poll_interval: float = 15,
     _poll_timeout: float = 3600,
@@ -4536,6 +4614,7 @@ def _forecast_wrapper(
         feature_contributions=feature_contributions,
         model_parameters=model_parameters,
         multivariate=multivariate,
+        job_timeout_seconds=job_timeout_seconds,
         _is_async_job=_is_async_job,
         _poll_interval=_poll_interval,
         _poll_timeout=_poll_timeout,
@@ -4655,6 +4734,7 @@ def _cross_validation_wrapper(
     model_parameters: _ExtraParamDataType,
     multivariate: bool,
     categorical_exog_list: Optional[list[str]] = None,
+    job_timeout_seconds: Optional[int] = None,
     _is_async_job: bool = False,
     _poll_interval: float = 15,
     _poll_timeout: float = 3600,
@@ -4685,6 +4765,7 @@ def _cross_validation_wrapper(
         model_parameters=model_parameters,
         multivariate=multivariate,
         categorical_exog_list=categorical_exog_list,
+        job_timeout_seconds=job_timeout_seconds,
         _is_async_job=_is_async_job,
         _poll_interval=_poll_interval,
         _poll_timeout=_poll_timeout,

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -230,6 +230,12 @@ _date_features_by_freq = {
 }
 
 
+# What a binary job's result endpoint answers while the payload has not been served yet. 202 is
+# what it returns today; 409 is kept for compatibility, and where it instead means the job ended
+# without a result, waiting is merely wasteful rather than wrong.
+_RESULT_NOT_READY_CODES = (HTTPStatus.ACCEPTED, HTTPStatus.CONFLICT)
+
+
 def _is_retriable_error(exc: Exception) -> bool:
     retriable_exceptions = (
         ConnectionResetError,
@@ -245,11 +251,6 @@ def _is_retriable_error(exc: Exception) -> bool:
     )
     retriable_codes = [
         HTTPStatus.REQUEST_TIMEOUT,
-        # A binary job's result endpoint answers 202 while the zip has not materialized yet, so
-        # "not ready" means poll again rather than give up. 409 is listed alongside it for
-        # compatibility; where it instead means the job ended without a result, retrying is
-        # merely wasteful rather than wrong.
-        HTTPStatus.ACCEPTED,
         HTTPStatus.CONFLICT,
         HTTPStatus.TOO_MANY_REQUESTS,
         HTTPStatus.BAD_GATEWAY,
@@ -1389,7 +1390,11 @@ class NixtlaClient:
             client=self,
             job_id=job_id,
             endpoint=endpoint,
-            get_result=lambda job_data: parse_result(job_data["result"]),
+            # A JSON result is inline in the status response, so there is nothing to wait for
+            # and the poll settings are unused.
+            get_result=lambda job_data, poll_interval, poll_timeout: parse_result(
+                job_data["result"]
+            ),
         )
 
     def _submit_binary_job(
@@ -1435,12 +1440,11 @@ class NixtlaClient:
         endpoint: str,
         job_id: str,
     ) -> tuple[httpx.Headers, bytes]:
-        """Fetch a binary job's result from its dedicated endpoint.
+        """Fetch a binary job's result from its dedicated endpoint, once.
 
         Binary results cannot be inlined into the JSON status response, so they are served
-        separately. The API answers 202 while the job has not yet succeeded, and 409 is treated
-        the same way; `_is_retriable_error` covers both -- callers should go through
-        `_retry_strategy` so that race resolves itself rather than surfacing.
+        separately. Callers go through `_wait_for_job_result_bytes`, which handles the
+        not-ready answer this can raise.
 
         The status check stays exact: anything other than 200 raises rather than returning a
         body, so a "not ready" JSON payload is never mistaken for the zip.
@@ -1454,6 +1458,44 @@ class NixtlaClient:
             raise ApiError(status_code=resp.status_code, body=body)
         return resp.headers, resp.content
 
+    def _wait_for_job_result_bytes(
+        self,
+        client: httpx.Client,
+        endpoint: str,
+        job_id: str,
+        poll_interval: float,
+        poll_timeout: float,
+    ) -> tuple[httpx.Headers, bytes]:
+        """Poll a binary job's result endpoint until the payload is served.
+
+        A succeeded job's result is not necessarily available the instant its status says so, and
+        the endpoint answers `_RESULT_NOT_READY_CODES` until it is. That is a polling state, not a
+        failure, so it gets its own bounded loop here rather than going through `_retry_strategy`:
+        waiting is not an error to log as one, and it should not spend the budget reserved for
+        transient network failures. Those are still retried, by the same loop.
+        """
+        deadline = time.monotonic() + poll_timeout
+        announced = False
+        while True:
+            try:
+                return self._get_job_result_bytes(client, endpoint, job_id)
+            except Exception as e:
+                not_ready = (
+                    isinstance(e, ApiError) and e.status_code in _RESULT_NOT_READY_CODES
+                )
+                if not not_ready and not _is_retriable_error(e):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise AsyncJobTimeoutError(
+                        job_id=job_id, poll_timeout=poll_timeout
+                    ) from e
+                if not announced:
+                    # Once per wait, not once per attempt: `poll_interval` may be small.
+                    logger.info("Waiting for the result of job %s...", job_id)
+                    announced = True
+                time.sleep(min(poll_interval, remaining))
+
     def _submit_and_wrap_binary_job(
         self,
         endpoint: str,
@@ -1466,13 +1508,15 @@ class NixtlaClient:
         the request metadata travels in a header rather than in the body.
         """
 
-        def get_result(job_data: dict[str, Any]) -> StepResult:
-            # The status response leaves `result` null for these tasks; the payload is
-            # served from the job's own result endpoint. Retried because that endpoint
-            # answers 202 until the result has materialized.
+        def get_result(
+            job_data: dict[str, Any], poll_interval: float, poll_timeout: float
+        ) -> StepResult:
+            # The status response leaves `result` null for these tasks; the payload is served
+            # from the job's own result endpoint, which may not have it the instant the status
+            # says succeeded.
             with self._make_client(**self._client_kwargs) as client:
-                headers, content = self._retry_strategy(self._get_job_result_bytes)(
-                    client=client, endpoint=endpoint, job_id=job_id
+                headers, content = self._wait_for_job_result_bytes(
+                    client, endpoint, job_id, poll_interval, poll_timeout
                 )
             return _build_step_result(headers, content)
 

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -63,6 +63,13 @@ from .async_job import (
     Job,
     JobStatus,
 )
+from .steps import (
+    CONTENT_TYPE as _STEP_CONTENT_TYPE,
+    METADATA_HEADER as _STEP_METADATA_HEADER,
+    StepResult,
+    build_request as _build_step_request,
+    build_result as _build_step_result,
+)
 
 if TYPE_CHECKING:
     try:
@@ -476,7 +483,7 @@ def _partition_series(
         else:
             part_series["X"] = [x[part_idxs] for x in series["X"]]
             if h > 0:
-                if series["X_future"] is None: 
+                if series["X_future"] is None:
                     part_series["X_future"] = None
                 else:
                     part_series["X_future"] = [
@@ -663,7 +670,9 @@ def _extract_categorical_exog(
 
     # Extract historical values for all cat cols from df.
     # futr_cat_cols appear in both df (history) and X_df (future); hist_cat_cols only in df.
-    df_cat_vals: dict[str, np.ndarray] = {c: df[c].to_numpy() for c in categorical_exog_list}
+    df_cat_vals: dict[str, np.ndarray] = {
+        c: df[c].to_numpy() for c in categorical_exog_list
+    }
 
     X_df_cat_future: list[list] = []
     if futr_cat_cols and X_df is not None:
@@ -690,7 +699,9 @@ def _validate_input_size(
         )
 
 
-def _ensure_local_dataframe(df: Any, *, method_name: str, sync_method_name: str) -> None:
+def _ensure_local_dataframe(
+    df: Any, *, method_name: str, sync_method_name: str
+) -> None:
     if not isinstance(df, (pd.DataFrame, pl_DataFrame)):
         raise ValueError(
             f"{method_name} only supports pandas or polars dataframes; "
@@ -804,6 +815,7 @@ def _forecast_payload_to_in_sample(payload: dict, h: int, n_windows: int) -> dic
 
     return payload
 
+
 def _get_in_sample_horizon_and_windows(
     sizes: np.ndarray,
     model_horizon: int,
@@ -818,11 +830,14 @@ def _get_in_sample_horizon_and_windows(
     if clean_ex_first:
         n_windows = max((min_size - model_input_size) // model_horizon, 1)
     else:
-        n_windows = max((min_size - (model_input_size + model_horizon + 2 * h)) // model_horizon, 1)
+        n_windows = max(
+            (min_size - (model_input_size + model_horizon + 2 * h)) // model_horizon, 1
+        )
     # In case of multiple windows, we reduce one to avoid errors when running with level argument
     if level is not None and n_windows > 1:
         n_windows -= 1
     return h, n_windows
+
 
 def _maybe_add_intervals(
     df: DFType,
@@ -1311,7 +1326,87 @@ class NixtlaClient:
             payload["job_options"] = {"timeout_seconds": job_timeout_seconds}
         with self._make_client(**self._client_kwargs) as client:
             job_id = self._submit_job(client, endpoint, payload)
-        return Job(client=self, job_id=job_id, endpoint=endpoint, parse_result=parse_result)
+        return Job(
+            client=self, job_id=job_id, endpoint=endpoint, parse_result=parse_result
+        )
+
+    def _submit_binary_job(
+        self,
+        client: httpx.Client,
+        endpoint: str,
+        metadata: str,
+        body: bytes,
+    ) -> str:
+        """Submit a job whose request body is opaque bytes rather than a JSON payload.
+
+        The body is sent as-is: it is an already-deflated zip, so the zstd compression
+        `_make_request` applies to large JSON payloads would only cost CPU. `content-type` is
+        overridden per-request because the client-level default is `application/json`.
+        """
+        headers = {
+            "content-type": _STEP_CONTENT_TYPE,
+            _STEP_METADATA_HEADER: metadata,
+        }
+        resp = client.post(url=f"{endpoint}/async", content=body, headers=headers)
+        try:
+            resp_body = orjson.loads(resp.content)
+        except orjson.JSONDecodeError:
+            raise ApiError(
+                status_code=resp.status_code,
+                body=f"Could not parse JSON: {resp.content}",
+            )
+        if resp.status_code not in (HTTPStatus.OK, HTTPStatus.ACCEPTED):
+            raise ApiError(status_code=resp.status_code, body=resp_body)
+        return resp_body["job_id"]
+
+    def _get_job_result_bytes(
+        self,
+        client: httpx.Client,
+        endpoint: str,
+        job_id: str,
+    ) -> tuple[Any, bytes]:
+        """Fetch a binary job's result from its dedicated endpoint.
+
+        Binary results cannot be inlined into the JSON status response, so they are served
+        separately. The server answers 409 while the job has not yet succeeded.
+        """
+        resp = client.get(f"{endpoint}/jobs/{job_id}/result")
+        if resp.status_code != HTTPStatus.OK:
+            try:
+                body = resp.json()
+            except Exception:
+                body = f"Could not parse JSON: {resp.content}"
+            raise ApiError(status_code=resp.status_code, body=body)
+        return resp.headers, resp.content
+
+    def _submit_and_wrap_binary_job(
+        self,
+        endpoint: str,
+        metadata: str,
+        body: bytes,
+    ) -> Job:
+        """Binary counterpart of `_submit_and_wrap_job`.
+
+        `job_options` is already folded into `metadata` by the caller, because for these tasks
+        the request metadata travels in a header rather than in the body.
+        """
+
+        def fetch_result(job_id: str) -> StepResult:
+            with self._make_client(**self._client_kwargs) as client:
+                headers, content = self._get_job_result_bytes(client, endpoint, job_id)
+            return _build_step_result(headers, content)
+
+        with self._make_client(**self._client_kwargs) as client:
+            job_id = self._retry_strategy(self._submit_binary_job)(
+                client=client, endpoint=endpoint, metadata=metadata, body=body
+            )
+        return Job(
+            client=self,
+            job_id=job_id,
+            endpoint=endpoint,
+            parse_result=lambda resp: resp,
+            fetch_result=fetch_result,
+        )
 
     def _make_partitioned_requests(
         self,
@@ -1808,7 +1903,10 @@ class NixtlaClient:
             model=model,
         )
         return self._submit_and_wrap_job(
-            "v2/finetune", payload, job_timeout_seconds, lambda resp: resp["finetuned_model_id"]
+            "v2/finetune",
+            payload,
+            job_timeout_seconds,
+            lambda resp: resp["finetuned_model_id"],
         )
 
     @overload
@@ -2062,7 +2160,11 @@ class NixtlaClient:
         sorted_df_cat: dict[str, np.ndarray] = {}
         if categorical_exog_list:
             for c, vals in df_cat_vals.items():
-                sorted_df_cat[c] = vals[processed.sort_idxs] if processed.sort_idxs is not None else vals
+                sorted_df_cat[c] = (
+                    vals[processed.sort_idxs]
+                    if processed.sort_idxs is not None
+                    else vals
+                )
 
         standard_freq = _standardize_freq(freq, processed)
         model_input_size, model_horizon = self._get_model_params(model, standard_freq)
@@ -2111,16 +2213,22 @@ class NixtlaClient:
             if futr_cols is not None:
                 logger.info(f"Using future exogenous features: {futr_cols}")
             if futr_cat_cols:
-                logger.info(f"Using future categorical exogenous features: {futr_cat_cols}")
+                logger.info(
+                    f"Using future categorical exogenous features: {futr_cat_cols}"
+                )
             if hist_exog_list:
                 logger.info(f"Using historical exogenous features: {hist_exog_list}")
             if hist_cat_cols:
-                logger.info(f"Using historical categorical exogenous features: {hist_cat_cols}")
+                logger.info(
+                    f"Using historical categorical exogenous features: {hist_cat_cols}"
+                )
         else:
             X = None
 
         if X_future is not None or X_df_cat_future:
-            X_future = (list(X_future) if X_future is not None else []) + X_df_cat_future
+            X_future = (
+                list(X_future) if X_future is not None else []
+            ) + X_df_cat_future
 
         categorical_exog_payload: Optional[list[int]] = None
         if categorical_exog_list:
@@ -2161,7 +2269,9 @@ class NixtlaClient:
         if model_parameters is not None:
             payload.update({"model_parameters": model_parameters})
 
-        weights_x_cols = x_cols[:n_futr_num] + futr_cat_cols + x_cols[n_futr_num:] + hist_cat_cols
+        weights_x_cols = (
+            x_cols[:n_futr_num] + futr_cat_cols + x_cols[n_futr_num:] + hist_cat_cols
+        )
 
         def parse_result(
             resp: dict[str, Any],
@@ -2214,7 +2324,9 @@ class NixtlaClient:
                             self.feature_contributions
                         )
             out = _maybe_drop_id(df=out, id_col=id_col, drop=drop_id)
-            self._maybe_assign_weights(weights=resp["weights_x"], df=df, x_cols=weights_x_cols)
+            self._maybe_assign_weights(
+                weights=resp["weights_x"], df=df, x_cols=weights_x_cols
+            )
             return out
 
         return payload, sizes, model_horizon, model_input_size, parse_result
@@ -2344,7 +2456,7 @@ class NixtlaClient:
                 the behavior of the model. Default is None
             multivariate (bool): If True, enables multivariate predictions.
                 Defaults to False. Note: multivariate predictions are only
-                supported for a select set of TimeGPT models. 
+                supported for a select set of TimeGPT models.
 
         Returns:
             pandas, polars, dask or spark DataFrame or ray Dataset:
@@ -2653,7 +2765,9 @@ class NixtlaClient:
             model_parameters=model_parameters,
             multivariate=multivariate,
         )
-        return self._submit_and_wrap_job("v2/forecast", payload, job_timeout_seconds, parse_result)
+        return self._submit_and_wrap_job(
+            "v2/forecast", payload, job_timeout_seconds, parse_result
+        )
 
     def _distributed_detect_anomalies(
         self,
@@ -2917,7 +3031,9 @@ class NixtlaClient:
         out = ufp.assign_columns(out, "anomaly", resp["anomaly"])
         out = _maybe_drop_id(df=out, id_col=id_col, drop=drop_id)
         weights_x_cols = x_cols + cat_cols
-        self._maybe_assign_weights(weights=resp["weights_x"], df=df, x_cols=weights_x_cols)
+        self._maybe_assign_weights(
+            weights=resp["weights_x"], df=df, x_cols=weights_x_cols
+        )
         return out
 
     def _distributed_detect_anomalies_online(
@@ -3092,10 +3208,10 @@ class NixtlaClient:
                 distributed environments. Defaults to None.
             multivariate (bool): If True, enables multivariate predictions.
                 Defaults to False. Note: multivariate predictions are only
-                supported for a select set of TimeGPT models. This variable 
+                supported for a select set of TimeGPT models. This variable
                 is different from the `threshold_method` parameter. The latter
                 controls the method used for anomaly detection (univariate vs
-                multivariate) whereas `multivariate` determines how the model 
+                multivariate) whereas `multivariate` determines how the model
                 creates the predictions.
 
         Returns:
@@ -3388,7 +3504,11 @@ class NixtlaClient:
         sorted_df_cat: dict[str, np.ndarray] = {}
         if categorical_exog_list:
             for c, vals in df_cat_vals.items():
-                sorted_df_cat[c] = vals[processed.sort_idxs] if processed.sort_idxs is not None else vals
+                sorted_df_cat[c] = (
+                    vals[processed.sort_idxs]
+                    if processed.sort_idxs is not None
+                    else vals
+                )
 
         standard_freq = _standardize_freq(freq, processed)
         model_input_size, model_horizon = self._get_model_params(model, standard_freq)
@@ -3397,7 +3517,9 @@ class NixtlaClient:
         if processed.sort_idxs is not None:
             targets = targets[processed.sort_idxs]
             times = times[processed.sort_idxs]
-        restrict_input = finetune_steps == 0 and not x_cols and not categorical_exog_list
+        restrict_input = (
+            finetune_steps == 0 and not x_cols and not categorical_exog_list
+        )
         if restrict_input:
             logger.info("Restricting input...")
             new_input_size = _restrict_input_samples(
@@ -3428,7 +3550,9 @@ class NixtlaClient:
             cat_col_indices = list(range(n_num_cols, n_num_cols + len(hist_cat_cols)))
             categorical_exog_payload = cat_col_indices
             if hist_cat_cols:
-                logger.info(f"Using historical categorical exogenous features: {hist_cat_cols}")
+                logger.info(
+                    f"Using historical categorical exogenous features: {hist_cat_cols}"
+                )
         else:
             X = list(X_np) if X_np is not None else None
 
@@ -3606,7 +3730,7 @@ class NixtlaClient:
                 will be equal to the available parallel resources in
                 distributed environments. Defaults to None.
             model_parameters (dict): The dictionary settings that determine
-                the behavior of the model. Default is None.            
+                the behavior of the model. Default is None.
             multivariate (bool): If True, enables multivariate predictions.
                 Defaults to False. Note: multivariate predictions are only
                 supported for a select set of TimeGPT models.
@@ -3871,6 +3995,76 @@ class NixtlaClient:
         return self._submit_and_wrap_job(
             "v2/cross_validation", payload, job_timeout_seconds, parse_result
         )
+
+    def submit_execute_step_job(
+        self,
+        func_name: str,
+        params: dict[str, Any],
+        data: Optional[dict[str, Any]] = None,
+        job_timeout_seconds: Optional[int] = None,
+    ) -> Job:
+        """Submit a single TSMP step to run asynchronously.
+
+        `execute_step` runs one TSMP top-level API call server-side in a fresh sandbox: nothing
+        is registered and nothing is cached between calls, so every request is self-contained
+        and carries its own data. This does not block; it submits the job and immediately
+        returns a `Job` handle. Call `job.wait()` to poll until it completes and get a
+        `StepResult`, or `job.cancel()` to request that the server stop it.
+
+        Tables are referenced from `params` by name using a `{"data_ref": "<key>"}` envelope,
+        where `<key>` is a key of `data`. Because a step's output tables can be passed straight
+        back in as the next step's `data`, calls chain without any file or byte handling::
+
+            step1 = nc.submit_execute_step_job(
+                "make_forecast_input",
+                {"data": {"data_ref": "panel"}, "freq": "D"},
+                data={"panel": df},
+            ).wait()
+
+            step2 = nc.submit_execute_step_job(
+                "forecast",
+                {"resource": {"data_ref": "result"}, "models": ["timegpt-1"], "h": 7},
+                data=step1.data,
+            ).wait()
+
+        Requires pyarrow (`pip install 'nixtla[steps]'`). Chaining relies on arrow schema
+        metadata that a pandas round-trip discards, so pass `step.data` between steps rather
+        than `step.to_pandas()`.
+
+        There is no `model` argument: a step names the models it runs inside `params`, and the
+        sandbox reaches them over the API rather than from a checkpoint local to one host.
+
+        Not reachable over this transport: `train` and `optimize_model`. Both require a
+        `tune.Space`, which has no JSON encoding.
+
+        Args:
+            func_name (str): TSMP top-level API to run, e.g. `'forecast'`,
+                `'make_forecast_input'`, `'cross_validate'`, `'preprocess'`, `'select_by_sql'`.
+            params (dict): Arguments for that API. Tables are referenced as
+                `{"data_ref": "<key>"}` envelopes naming a key of `data`; everything else is
+                passed through as-is and must be JSON serializable.
+            data (dict, optional): Tables the params reference, as pyarrow Tables or eager
+                pandas/polars DataFrames, keyed by the name used in the `data_ref` envelopes.
+                Keys must be bare names. Defaults to None.
+            job_timeout_seconds (int, optional): Maximum seconds the server allows this job to
+                run before terminating it server-side. This is separate from `poll_timeout` in
+                `Job.wait()`, which only controls how long the client polls locally. Capped by
+                a server-side per-task maximum; requesting a higher value raises `ApiError`
+                (422) when submitting. Defaults to the server's default for this task type if
+                not specified.
+
+        Returns:
+            Job: Handle to the submitted job. `job.wait()` returns a `StepResult` with `.data`
+                (result tables as pyarrow Tables) and `.metadata` (the server's `func_name`,
+                `result` envelope and output `profile`).
+        """
+        metadata, body = _build_step_request(
+            func_name=func_name,
+            params=params,
+            data=data,
+            job_timeout_seconds=job_timeout_seconds,
+        )
+        return self._submit_and_wrap_binary_job("v2/execute_step", metadata, body)
 
     def plot(
         self,
@@ -4235,7 +4429,7 @@ def _forecast_wrapper(
     model: _Model,
     num_partitions: Optional[_PositiveInt],
     feature_contributions: bool,
-    model_parameters:_ExtraParamDataType,
+    model_parameters: _ExtraParamDataType,
     multivariate: bool,
     _is_async_job: bool = False,
     _poll_interval: float = 15,
@@ -4338,7 +4532,7 @@ def _detect_anomalies_online_wrapper(
     model: _Model,
     refit: bool,
     num_partitions: Optional[_PositiveInt],
-    multivariate: bool
+    multivariate: bool,
 ) -> pd.DataFrame:
     return client.detect_anomalies_online(
         df=df,

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -245,6 +245,11 @@ def _is_retriable_error(exc: Exception) -> bool:
     )
     retriable_codes = [
         HTTPStatus.REQUEST_TIMEOUT,
+        # A binary job's result endpoint answers 202 while the zip has not materialized yet, so
+        # "not ready" means poll again rather than give up. 409 stays listed because older servers
+        # used it for that same case; on current ones it means the job ended without a result, and
+        # retrying is merely wasteful rather than wrong.
+        HTTPStatus.ACCEPTED,
         HTTPStatus.CONFLICT,
         HTTPStatus.TOO_MANY_REQUESTS,
         HTTPStatus.BAD_GATEWAY,
@@ -1300,7 +1305,16 @@ class NixtlaClient:
         multithreaded_compress: bool = True,
     ) -> dict[str, Any]:
         job_id = self._submit_job(client, endpoint, payload, multithreaded_compress)
-        job_data = self._poll_job(client, endpoint, job_id, poll_interval, poll_timeout)
+        try:
+            job_data = self._poll_job(
+                client, endpoint, job_id, poll_interval, poll_timeout
+            )
+        except AsyncJobTimeoutError:
+            # This job's id is never surfaced to the caller, so if we don't cancel it
+            # here nobody can -- it would run to its server-side deadline unwatched.
+            # Other terminal states (failed/cancelled) need no cancellation.
+            self._cancel_job_best_effort(client, job_id, "client poll timeout")
+            raise
         return job_data["result"]
 
     def _cancel_job(self, client: httpx.Client, job_id: str) -> None:
@@ -1315,6 +1329,23 @@ class NixtlaClient:
             except Exception:
                 body = f"Could not parse JSON: {resp.content}"
             raise ApiError(status_code=resp.status_code, body=body)
+
+    def _cancel_job_best_effort(
+        self, client: httpx.Client, job_id: str, reason: str
+    ) -> bool:
+        """Request cancellation, swallowing failures. Returns True if accepted.
+
+        Used on cleanup paths where an exception is already propagating: failing to
+        cancel must not mask it.
+        """
+        try:
+            self._cancel_job(client, job_id)
+        except Exception:
+            logger.warning(
+                "Failed to cancel job %s (%s)", job_id, reason, exc_info=True
+            )
+            return False
+        return True
 
     def _submit_and_wrap_job(
         self,
@@ -1376,9 +1407,12 @@ class NixtlaClient:
         """Fetch a binary job's result from its dedicated endpoint.
 
         Binary results cannot be inlined into the JSON status response, so they are served
-        separately. The server answers 409 while the job has not yet succeeded, which
-        `_is_retriable_error` treats as retriable -- callers should go through
-        `_retry_strategy` so that race resolves itself rather than surfacing.
+        separately. The server answers 202 while the job has not yet succeeded (older servers
+        answered 409), and `_is_retriable_error` treats both as retriable -- callers should go
+        through `_retry_strategy` so that race resolves itself rather than surfacing.
+
+        The status check stays exact: anything other than 200 raises rather than returning a
+        body, so a "not ready" JSON payload is never mistaken for the zip.
         """
         resp = client.get(f"{endpoint}/jobs/{job_id}/result")
         if resp.status_code != HTTPStatus.OK:
@@ -1404,7 +1438,7 @@ class NixtlaClient:
         def get_result(job_data: dict[str, Any]) -> StepResult:
             # The status response leaves `result` null for these tasks; the payload is
             # served from the job's own result endpoint. Retried because that endpoint
-            # answers 409 until the result has materialized.
+            # answers 202 until the result has materialized.
             with self._make_client(**self._client_kwargs) as client:
                 headers, content = self._retry_strategy(self._get_job_result_bytes)(
                     client=client, endpoint=endpoint, job_id=job_id
@@ -1433,8 +1467,9 @@ class NixtlaClient:
         max_workers = min(10, num_partitions)
         # NOTE: if one partition's job fails/times out, this still waits for
         # every other in-flight partition to reach a terminal state before the
-        # exception surfaces (ThreadPoolExecutor.__exit__ -> shutdown(wait=True));
-        # there's no cross-partition cancellation here (unlike Job.cancel()).
+        # exception surfaces (ThreadPoolExecutor.__exit__ -> shutdown(wait=True)).
+        # A timed-out partition cancels its own job (see `_run_async_job`), but
+        # there's still no cross-partition cancellation here: the siblings run on.
         with ThreadPoolExecutor(max_workers) as executor:
             if _is_async_job:
                 future2pos = {

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -4045,9 +4045,9 @@ class NixtlaClient:
                 data=step1.data,
             ).wait()
 
-        Requires pyarrow (`pip install 'nixtla[steps]'`). Chaining relies on
-        arrow schema metadata that a pandas round-trip discards, so pass
-        `step.data` between steps rather than `step.to_pandas()`.
+        Chaining relies on arrow schema metadata that a pandas round-trip
+        discards, so pass `step.data` between steps rather than
+        `step.to_pandas()`.
 
         There is no `model` argument: a step names the models it runs inside
         `params`, and the sandbox reaches them over the API rather than from
@@ -4076,7 +4076,6 @@ class NixtlaClient:
                 server's default for this task type if not specified.
 
         Raises:
-            ImportError: If pyarrow is not installed.
             TypeError: If a `data` value is not a pyarrow Table or an eager
                 pandas/polars DataFrame.
             ValueError: If a `ref` names a table that `data` does not supply,

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -6,6 +6,8 @@ __all__ = [
     "Job",
     "JobStatus",
     "NixtlaClient",
+    "StepResult",
+    "ref",
 ]
 
 import datetime
@@ -69,6 +71,7 @@ from .steps import (
     StepResult,
     build_request as _build_step_request,
     build_result as _build_step_result,
+    ref,
 )
 
 if TYPE_CHECKING:
@@ -412,9 +415,7 @@ def _times_to_iso(times: np.ndarray, tz: Optional[str] = None) -> Optional[list[
                 _warn_non_constant_offset(tz)
                 return None
             # the values are UTC instants; re-attach the original zone's offset
-            return [
-                pd.Timestamp(t, tz="UTC").tz_convert(tz).isoformat() for t in times
-            ]
+            return [pd.Timestamp(t, tz="UTC").tz_convert(tz).isoformat() for t in times]
         return np.datetime_as_string(times, unit="auto").tolist()
     return None
 
@@ -1323,11 +1324,18 @@ class NixtlaClient:
         parse_result: Callable[..., Any],
     ) -> Job:
         if job_timeout_seconds is not None:
-            payload["job_options"] = {"timeout_seconds": job_timeout_seconds}
+            # Don't mutate the caller's dict: `forecast` reuses its payload for add_history.
+            payload = {
+                **payload,
+                "job_options": {"timeout_seconds": job_timeout_seconds},
+            }
         with self._make_client(**self._client_kwargs) as client:
             job_id = self._submit_job(client, endpoint, payload)
         return Job(
-            client=self, job_id=job_id, endpoint=endpoint, parse_result=parse_result
+            client=self,
+            job_id=job_id,
+            endpoint=endpoint,
+            get_result=lambda job_data: parse_result(job_data["result"]),
         )
 
     def _submit_binary_job(
@@ -1364,11 +1372,13 @@ class NixtlaClient:
         client: httpx.Client,
         endpoint: str,
         job_id: str,
-    ) -> tuple[Any, bytes]:
+    ) -> tuple[httpx.Headers, bytes]:
         """Fetch a binary job's result from its dedicated endpoint.
 
         Binary results cannot be inlined into the JSON status response, so they are served
-        separately. The server answers 409 while the job has not yet succeeded.
+        separately. The server answers 409 while the job has not yet succeeded, which
+        `_is_retriable_error` treats as retriable -- callers should go through
+        `_retry_strategy` so that race resolves itself rather than surfacing.
         """
         resp = client.get(f"{endpoint}/jobs/{job_id}/result")
         if resp.status_code != HTTPStatus.OK:
@@ -1391,22 +1401,21 @@ class NixtlaClient:
         the request metadata travels in a header rather than in the body.
         """
 
-        def fetch_result(job_id: str) -> StepResult:
+        def get_result(job_data: dict[str, Any]) -> StepResult:
+            # The status response leaves `result` null for these tasks; the payload is
+            # served from the job's own result endpoint. Retried because that endpoint
+            # answers 409 until the result has materialized.
             with self._make_client(**self._client_kwargs) as client:
-                headers, content = self._get_job_result_bytes(client, endpoint, job_id)
+                headers, content = self._retry_strategy(self._get_job_result_bytes)(
+                    client=client, endpoint=endpoint, job_id=job_id
+                )
             return _build_step_result(headers, content)
 
         with self._make_client(**self._client_kwargs) as client:
             job_id = self._retry_strategy(self._submit_binary_job)(
                 client=client, endpoint=endpoint, metadata=metadata, body=body
             )
-        return Job(
-            client=self,
-            job_id=job_id,
-            endpoint=endpoint,
-            parse_result=lambda resp: resp,
-            fetch_result=fetch_result,
-        )
+        return Job(client=self, job_id=job_id, endpoint=endpoint, get_result=get_result)
 
     def _make_partitioned_requests(
         self,
@@ -2178,7 +2187,12 @@ class NixtlaClient:
                 "this may lead to less accurate forecasts. "
                 "Please consider using a smaller horizon."
             )
-        restrict_input = finetune_steps == 0 and not x_cols and not categorical_exog_list and not add_history
+        restrict_input = (
+            finetune_steps == 0
+            and not x_cols
+            and not categorical_exog_list
+            and not add_history
+        )
         orig_indptr: Optional[np.ndarray] = None
         orig_sort_idxs: Optional[np.ndarray] = None
         if restrict_input:
@@ -4005,53 +4019,70 @@ class NixtlaClient:
     ) -> Job:
         """Submit a single TSMP step to run asynchronously.
 
-        `execute_step` runs one TSMP top-level API call server-side in a fresh sandbox: nothing
-        is registered and nothing is cached between calls, so every request is self-contained
-        and carries its own data. This does not block; it submits the job and immediately
-        returns a `Job` handle. Call `job.wait()` to poll until it completes and get a
+        `execute_step` runs one TSMP top-level API call server-side in a
+        fresh sandbox: nothing is registered and nothing is cached between
+        calls, so every request is self-contained and carries its own data.
+        This does not block; it submits the job and immediately returns a
+        `Job` handle. Call `job.wait()` to poll until it completes and get a
         `StepResult`, or `job.cancel()` to request that the server stop it.
 
-        Tables are referenced from `params` by name using a `{"data_ref": "<key>"}` envelope,
-        where `<key>` is a key of `data`. Because a step's output tables can be passed straight
-        back in as the next step's `data`, calls chain without any file or byte handling::
+        Tables are referenced from `params` with `nixtla.ref(key)`, naming a
+        key of `data`. Because a step's output tables can be passed straight
+        back in as the next step's `data`, calls chain without any file or
+        byte handling::
+
+            from nixtla import ref
 
             step1 = nc.submit_execute_step_job(
                 "make_forecast_input",
-                {"data": {"data_ref": "panel"}, "freq": "D"},
+                {"data": ref("panel"), "freq": "D"},
                 data={"panel": df},
             ).wait()
 
             step2 = nc.submit_execute_step_job(
                 "forecast",
-                {"resource": {"data_ref": "result"}, "models": ["timegpt-1"], "h": 7},
+                {"resource": ref("result"), "models": ["timegpt-1"], "h": 7},
                 data=step1.data,
             ).wait()
 
-        Requires pyarrow (`pip install 'nixtla[steps]'`). Chaining relies on arrow schema
-        metadata that a pandas round-trip discards, so pass `step.data` between steps rather
-        than `step.to_pandas()`.
+        Requires pyarrow (`pip install 'nixtla[steps]'`). Chaining relies on
+        arrow schema metadata that a pandas round-trip discards, so pass
+        `step.data` between steps rather than `step.to_pandas()`.
 
-        There is no `model` argument: a step names the models it runs inside `params`, and the
-        sandbox reaches them over the API rather than from a checkpoint local to one host.
+        There is no `model` argument: a step names the models it runs inside
+        `params`, and the sandbox reaches them over the API rather than from
+        a checkpoint local to one host.
 
-        Not reachable over this transport: `train` and `optimize_model`. Both require a
-        `tune.Space`, which has no JSON encoding.
+        Not reachable over this transport: `train` and `optimize_model`.
+        Both require a `tune.Space`, which has no JSON encoding.
 
         Args:
             func_name (str): TSMP top-level API to run, e.g. `'forecast'`,
-                `'make_forecast_input'`, `'cross_validate'`, `'preprocess'`, `'select_by_sql'`.
-            params (dict): Arguments for that API. Tables are referenced as
-                `{"data_ref": "<key>"}` envelopes naming a key of `data`; everything else is
-                passed through as-is and must be JSON serializable.
-            data (dict, optional): Tables the params reference, as pyarrow Tables or eager
-                pandas/polars DataFrames, keyed by the name used in the `data_ref` envelopes.
-                Keys must be bare names. Defaults to None.
-            job_timeout_seconds (int, optional): Maximum seconds the server allows this job to
-                run before terminating it server-side. This is separate from `poll_timeout` in
-                `Job.wait()`, which only controls how long the client polls locally. Capped by
-                a server-side per-task maximum; requesting a higher value raises `ApiError`
-                (422) when submitting. Defaults to the server's default for this task type if
-                not specified.
+                `'make_forecast_input'`, `'cross_validate'`, `'preprocess'`,
+                `'select_by_sql'`.
+            params (dict): Arguments for that API. Tables are referenced by
+                `ref(key)` envelopes naming a key of `data`; everything else
+                is passed through as-is and must be JSON serializable.
+            data (dict, optional): Tables the params reference, as pyarrow
+                Tables or eager pandas/polars DataFrames, keyed by the name
+                used in the `ref` envelopes. Keys must be bare names.
+                Defaults to None.
+            job_timeout_seconds (int, optional): Maximum seconds the server
+                allows this job to run before terminating it server-side.
+                This is separate from `poll_timeout` in `Job.wait()`, which
+                only controls how long the client polls locally. Capped by a
+                server-side per-task maximum; requesting a higher value
+                raises `ApiError` (422) when submitting. Defaults to the
+                server's default for this task type if not specified.
+
+        Raises:
+            ImportError: If pyarrow is not installed.
+            TypeError: If a `data` value is not a pyarrow Table or an eager
+                pandas/polars DataFrame.
+            ValueError: If a `ref` names a table that `data` does not supply,
+                a `data` key is not a bare name, or the encoded metadata
+                exceeds the header budget. All are raised locally, before
+                anything is uploaded.
 
         Returns:
             Job: Handle to the submitted job. `job.wait()` returns a `StepResult` with `.data`

--- a/nixtla/scripts/snowflake_install_nixtla.py
+++ b/nixtla/scripts/snowflake_install_nixtla.py
@@ -49,6 +49,7 @@ PACKAGES = [
     "httpcore",
     "orjson",
     "pandas",
+    "pyarrow",
     "tenacity",
     "tqdm",
     "numpy",

--- a/nixtla/steps.py
+++ b/nixtla/steps.py
@@ -1,0 +1,253 @@
+"""Client-side codec for the `execute_step` endpoint.
+
+`execute_step` runs one TSMP top-level API call server-side in a fresh sandbox. Unlike the other
+endpoints it does not exchange JSON: the request body is a zip of `<key>.parquet` members and all
+of its metadata rides in a `nixtla-metadata` header. The invariant is that the zip is data and the
+header is metadata, so there is exactly one place to look for each.
+
+Nothing here understands TSMP semantics. Tables returned by the server carry their resource
+identity in arrow schema metadata, and this module passes that through untouched, which is what
+makes chaining one step's output into the next lossless. That is also why pyarrow is required
+rather than optional: a pandas round-trip drops schema metadata, so a chained call would silently
+misread the previous step's output as an untyped table.
+"""
+
+import io
+import json
+import zipfile
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any, Iterable, Optional
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import pyarrow as pa
+
+METADATA_HEADER = "nixtla-metadata"
+CONTENT_TYPE = "application/zip"
+PARQUET_SUFFIX = ".parquet"
+REF_KEY = "data_ref"
+
+# Tightest common proxy limit (nginx large_client_header_buffers 8k, CloudFront 8k). The server
+# rejects anything larger with 431 and deliberately does not spill metadata into the body, so the
+# client checks the same budget to fail before uploading rather than after.
+HEADER_BUDGET = 8192
+
+_PYARROW_HINT = "submit_execute_step_job requires pyarrow. Install it with: pip install 'nixtla[steps]'"
+
+
+def _require_pyarrow():
+    """Import pyarrow on demand so the rest of the SDK stays installable without it."""
+    try:
+        import pyarrow as pa  # noqa: F401
+        import pyarrow.parquet as pq  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised via the error path only
+        raise ImportError(_PYARROW_HINT) from exc
+    return pa, pq
+
+
+def ref(key: str) -> dict[str, str]:
+    """Build the params envelope naming a table in the data map.
+
+    Args:
+        key (str): Key of the table in the `data` mapping.
+
+    Returns:
+        dict: `{"data_ref": key}`, the envelope `params` uses to reference a table.
+    """
+    return {REF_KEY: key}
+
+
+def collect_refs(obj: Any) -> set[str]:
+    """Every `data_ref` in a params tree, so a bad reference is caught before uploading."""
+    if isinstance(obj, dict):
+        if REF_KEY in obj:
+            key = obj[REF_KEY]
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"{REF_KEY} must be a string, got {type(key).__name__}"
+                )
+            return {key}
+        return set().union(*(collect_refs(v) for v in obj.values())) if obj else set()
+    if isinstance(obj, (list, tuple)):
+        return set().union(*(collect_refs(v) for v in obj)) if obj else set()
+    return set()
+
+
+def validate_member_names(names: Iterable[str]) -> None:
+    """Require every data-map key to be a bare name.
+
+    Keys become archive member names, so a nested or absolute path would be a traversal attempt.
+    The server enforces this too; checking here turns a post-upload 400 into a local error.
+    """
+    for name in names:
+        if not name or name != name.strip():
+            raise ValueError(f"invalid data key: {name!r}")
+        path = PurePosixPath(name)
+        if (
+            path.is_absolute()
+            or ".." in path.parts
+            or len(path.parts) != 1
+            or "\\" in name
+        ):
+            raise ValueError(f"unsafe data key: {name!r} (must be a bare name)")
+
+
+def to_arrow(obj: Any) -> "pa.Table":
+    """Coerce a supported table-like object to a `pyarrow.Table`.
+
+    A `pa.Table` is returned unchanged so that a table received from a previous step keeps its
+    schema metadata. pandas and polars frames go through narwhals, the compatibility layer the rest
+    of the SDK already uses.
+    """
+    pa, _ = _require_pyarrow()
+    if isinstance(obj, pa.Table):
+        return obj
+
+    import narwhals as nw
+
+    try:
+        frame = nw.from_native(obj, eager_only=True)
+    except TypeError as exc:
+        raise TypeError(
+            "execute_step data values must be pyarrow Tables or eager pandas/polars DataFrames, "
+            f"got {type(obj).__name__}"
+        ) from exc
+    return frame.to_arrow()
+
+
+def pack(tables: dict[str, "pa.Table"]) -> bytes:
+    """Serialize each table to a `<key>.parquet` member and zip them.
+
+    Members are written in sorted order so the same data map always produces the same bytes.
+    """
+    _, pq = _require_pyarrow()
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for key in sorted(tables):
+            member = io.BytesIO()
+            pq.write_table(tables[key], member)
+            zf.writestr(key + PARQUET_SUFFIX, member.getvalue())
+    return buf.getvalue()
+
+
+def unpack(body: bytes) -> dict[str, "pa.Table"]:
+    """Parse a response archive back into a data map keyed the way the caller will reference it."""
+    _, pq = _require_pyarrow()
+    tables: dict[str, "pa.Table"] = {}
+    with zipfile.ZipFile(io.BytesIO(body)) as zf:
+        for name in zf.namelist():
+            if not name.endswith(PARQUET_SUFFIX):
+                continue
+            tables[name[: -len(PARQUET_SUFFIX)]] = pq.read_table(
+                io.BytesIO(zf.read(name))
+            )
+    return tables
+
+
+def encode_metadata(metadata: dict[str, Any]) -> str:
+    """Serialize the request metadata, refusing anything that will not fit the header.
+
+    `json.dumps` defaults to `ensure_ascii=True`, so the value is pure ASCII and therefore safe as
+    an HTTP header. Metadata is never moved into the body: the archive holds tables and nothing
+    else, so an oversized header is a bad request rather than something to route around.
+    """
+    payload = json.dumps(metadata)
+    size = len(payload.encode())
+    if size > HEADER_BUDGET:
+        raise ValueError(
+            f"{METADATA_HEADER} would be {size} bytes, over the {HEADER_BUDGET}-byte budget. "
+            f"Shrink the request (a shorter SQL string, fewer models, fewer quantiles); metadata "
+            f"is never moved into the body."
+        )
+    return payload
+
+
+def decode_metadata(headers: Any) -> dict[str, Any]:
+    """Read the response metadata header. HTTP header names are not case-sensitive."""
+    for key, value in dict(headers).items():
+        if key.lower() == METADATA_HEADER:
+            return json.loads(value)
+    return {}
+
+
+class StepResult:
+    """Result of an `execute_step` job.
+
+    Attributes:
+        data (dict): Result tables keyed by name, as `pyarrow.Table`. Pass this straight back as
+            the `data` argument of the next step to chain calls without losing the tables'
+            resource identity.
+        metadata (dict): What the server reported about the call — `func_name`, the `result`
+            envelope, and a `profile` of the output when the result is a dataframe.
+    """
+
+    def __init__(self, *, data: dict[str, "pa.Table"], metadata: dict[str, Any]):
+        self.data = data
+        self.metadata = metadata
+
+    def __getitem__(self, key: str) -> "pa.Table":
+        return self.data[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.data
+
+    def keys(self):
+        return self.data.keys()
+
+    def to_pandas(self) -> dict[str, "pd.DataFrame"]:
+        """Convert every result table to a pandas DataFrame.
+
+        Convenience for inspecting a final result. Do not feed the output of this back into a
+        chained step: the conversion drops the arrow schema metadata carrying the table's resource
+        identity. Pass `.data` instead.
+        """
+        return {key: table.to_pandas() for key, table in self.data.items()}
+
+    def __repr__(self) -> str:
+        func_name = self.metadata.get("func_name", "?")
+        shapes = ", ".join(
+            f"{k}: {v.num_rows}x{v.num_columns}" for k, v in self.data.items()
+        )
+        return f"StepResult(func_name={func_name!r}, data={{{shapes}}})"
+
+
+def build_result(headers: Any, body: bytes) -> StepResult:
+    """Assemble a `StepResult` from a raw `(headers, body)` response pair."""
+    return StepResult(data=unpack(body), metadata=decode_metadata(headers))
+
+
+def build_request(
+    func_name: str,
+    params: dict[str, Any],
+    data: Optional[dict[str, Any]] = None,
+    job_timeout_seconds: Optional[int] = None,
+) -> tuple[str, bytes]:
+    """Validate and encode one execute_step call into `(metadata_header, zip_body)`.
+
+    Validation mirrors the server's own checks so a malformed request fails locally rather than
+    after a full upload.
+    """
+    tables = {key: to_arrow(value) for key, value in (data or {}).items()}
+    validate_member_names(tables)
+
+    refs = collect_refs(params)
+    missing = refs - set(tables)
+    if missing:
+        raise ValueError(
+            f"params reference data keys that were not supplied: {sorted(missing)}; "
+            f"supplied: {sorted(tables)}"
+        )
+    unused = set(tables) - refs
+    if unused:
+        raise ValueError(
+            f"data contains tables no param references: {sorted(unused)}. "
+            f"They would be uploaded and ignored."
+        )
+
+    metadata: dict[str, Any] = {
+        "func_name": func_name,
+        "params": params,
+    }
+    if job_timeout_seconds is not None:
+        metadata["job_options"] = {"timeout_seconds": job_timeout_seconds}
+    return encode_metadata(metadata), pack(tables)

--- a/nixtla/steps.py
+++ b/nixtla/steps.py
@@ -1,9 +1,9 @@
 """Client-side codec for the `execute_step` endpoint.
 
-`execute_step` runs one TSMP top-level API call server-side in a fresh sandbox. Unlike the other
-endpoints it does not exchange JSON: the request body is a zip of `<key>.parquet` members and all
-of its metadata rides in a `nixtla-metadata` header. The invariant is that the zip is data and the
-header is metadata, so there is exactly one place to look for each.
+`execute_step` runs one TSMP top-level API call server-side. Unlike the other endpoints it does not
+exchange JSON: the request body is a zip of `<key>.parquet` members and all of its metadata rides in
+a `nixtla-metadata` header. The invariant is that the zip is data and the header is metadata, so
+there is exactly one place to look for each.
 
 Nothing here understands TSMP semantics. Tables returned by the server carry their resource
 identity in arrow schema metadata, and this module passes that through untouched, which is what
@@ -36,10 +36,18 @@ CONTENT_TYPE = "application/zip"
 _PARQUET_SUFFIX = ".parquet"
 _REF_KEY = "data_ref"
 
-# Tightest common proxy limit (nginx large_client_header_buffers 8k, CloudFront 8k). The server
-# rejects anything larger with 431 and deliberately does not spill metadata into the body, so the
-# client checks the same budget to fail before uploading rather than after.
+# The largest metadata header the API accepts. Metadata is never moved into the body -- the archive
+# holds tables and nothing else -- so an oversized header is a bad request rather than something to
+# route around. Checked here to fail before uploading rather than after.
 HEADER_BUDGET = 8192
+
+# The other limits the API places on a request. Exceeding one of these is reported as a failed job
+# rather than as an error when the job is submitted, so it would otherwise surface long after the
+# call that caused it. Checking locally turns that back into an immediate ValueError.
+MAX_BODY_BYTES = 32 * 1024 * 1024
+MAX_MEMBERS = 512
+MAX_METADATA_DEPTH = 32
+MAX_FUNC_NAME_LENGTH = 128
 
 
 def ref(key: str) -> dict[str, str]:
@@ -57,10 +65,13 @@ def ref(key: str) -> dict[str, str]:
 def _collect_refs(obj: Any) -> set[str]:
     """Every `data_ref` in a params tree, so a bad reference is caught before uploading.
 
-    An envelope's siblings are still walked: a param can hold both a `data_ref` and nested
-    params that reference further tables, and missing one of those would reject a valid call.
+    An envelope terminates the walk, exactly as it does server-side: the server replaces the whole
+    dict with the one table `data_ref` names and never looks at its siblings. A ref nested under an
+    envelope would therefore be silently ignored -- the table gets uploaded and the param it was
+    meant for stays unset -- so it is rejected here rather than left to produce a quietly wrong
+    result. Siblings that are not refs (the `resource`/`schema_expr` a step's own `result` envelope
+    carries) are passed through untouched, so a result envelope can be fed straight back in.
     """
-    refs: set[str] = set()
     if isinstance(obj, dict):
         if _REF_KEY in obj:
             key = obj[_REF_KEY]
@@ -68,13 +79,21 @@ def _collect_refs(obj: Any) -> set[str]:
                 raise ValueError(
                     f"{_REF_KEY} must be a string, got {type(key).__name__}"
                 )
-            refs.add(key)
-        for value in obj.values():
-            refs |= _collect_refs(value)
-    elif isinstance(obj, (list, tuple)):
-        for value in obj:
-            refs |= _collect_refs(value)
-    return refs
+            ignored: set[str] = set()
+            for name, value in obj.items():
+                if name != _REF_KEY:
+                    ignored |= _collect_refs(value)
+            if ignored:
+                raise ValueError(
+                    f"the {_REF_KEY} envelope naming {key!r} also nests {sorted(ignored)}; the "
+                    f"server replaces the whole envelope with that one table and never reads a "
+                    f"nested reference. Pass the nested table as its own param instead."
+                )
+            return {key}
+        return {r for value in obj.values() for r in _collect_refs(value)}
+    if isinstance(obj, (list, tuple)):
+        return {r for value in obj for r in _collect_refs(value)}
+    return set()
 
 
 def _validate_member_names(names: Iterable[str]) -> None:
@@ -96,18 +115,44 @@ def _validate_member_names(names: Iterable[str]) -> None:
             raise ValueError(f"unsafe data key: {name!r} (must be a bare name)")
 
 
+def _normalize_pandas_index(obj: Any) -> Any:
+    """Fold a pandas index into columns, or drop it, so it never reaches arrow as one.
+
+    Arrow serializes any non-default index as a column, which is how an ordinary filtered frame
+    (`df[df.y > 1]` leaves a non-contiguous index) grows a phantom `__index_level_0__` that TSMP
+    then rebuilds the resource around. A named index is folded into a real column instead of being
+    discarded: it usually holds the id or timestamp the caller means to send, and dropping it
+    silently would cost them the column. Anything else is positional bookkeeping and is dropped.
+
+    A no-op for non-pandas input, so polars and arrow reach `to_arrow` untouched.
+    """
+    # Imported here rather than at module scope only to keep pandas out of this module's import
+    # graph; it is a hard dependency of the SDK, so this always resolves.
+    import pandas as pd
+
+    if not isinstance(obj, pd.DataFrame):
+        return obj
+    index = obj.index
+    if isinstance(index, pd.RangeIndex) and index.start == 0 and index.step == 1:
+        # What arrow already stores as metadata rather than as a column; nothing to do.
+        return obj
+    return obj.reset_index(drop=all(name is None for name in index.names))
+
+
 def to_arrow(obj: Any) -> pa.Table:
     """Coerce a supported table-like object to a `pyarrow.Table`.
 
     A `pa.Table` is returned unchanged so that a table received from a previous step keeps its
     schema metadata. pandas and polars frames go through narwhals, which is already a hard
     dependency and reaches arrow in one hop; the rest of the client converts via utilsforecast.
+
+    A pandas index is never sent as data -- see `_normalize_pandas_index`.
     """
     if isinstance(obj, pa.Table):
         return obj
 
     try:
-        frame = nw.from_native(obj, eager_only=True)
+        frame = nw.from_native(_normalize_pandas_index(obj), eager_only=True)
     except TypeError as exc:
         raise TypeError(
             "execute_step data values must be pyarrow Tables or eager pandas/polars DataFrames, "
@@ -146,14 +191,34 @@ def _unpack(body: bytes) -> dict[str, pa.Table]:
     return tables
 
 
+def _check_metadata_depth(obj: Any) -> None:
+    """Reject metadata nested deeper than the server will parse.
+
+    Iterative on purpose: a recursive walk would hit the very limit it exists to enforce.
+    """
+    stack: list[tuple[Any, int]] = [(obj, 1)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > MAX_METADATA_DEPTH:
+            raise ValueError(
+                f"{METADATA_HEADER} nests deeper than {MAX_METADATA_DEPTH} levels; flatten the "
+                f"params."
+            )
+        if isinstance(node, dict):
+            stack.extend((v, depth + 1) for v in node.values())
+        elif isinstance(node, (list, tuple)):
+            stack.extend((x, depth + 1) for x in node)
+
+
 def _encode_metadata(metadata: dict[str, Any]) -> str:
-    """Serialize the request metadata, refusing anything that will not fit the header.
+    """Serialize the request metadata, refusing anything the server would not parse.
 
     `json.dumps` defaults to `ensure_ascii=True`, so the value is pure ASCII -- one byte per
     character, and safe as an HTTP header. Metadata is never moved into the body: the archive
     holds tables and nothing else, so an oversized header is a bad request rather than
     something to route around.
     """
+    _check_metadata_depth(metadata)
     payload = json.dumps(metadata)
     size = len(payload)
     if size > HEADER_BUDGET:
@@ -166,9 +231,30 @@ def _encode_metadata(metadata: dict[str, Any]) -> str:
 
 
 def _decode_metadata(headers: Mapping[str, str]) -> dict[str, Any]:
-    """Read the response metadata header, or `{}` when the server sent none."""
+    """Read the response metadata header, or `{}` when the server sent none.
+
+    A header that will not parse is warned about rather than raised on: a result whose tables came
+    back intact should not be discarded because the metadata describing it is unusable. The tables
+    are in `.data` either way.
+    """
     value = headers.get(METADATA_HEADER)
-    return json.loads(value) if value else {}
+    if not value:
+        return {}
+    try:
+        metadata = json.loads(value)
+    except json.JSONDecodeError:
+        logger.warning(
+            "ignoring unparseable %s header on step result: %r", METADATA_HEADER, value
+        )
+        return {}
+    if not isinstance(metadata, dict):
+        logger.warning(
+            "ignoring %s header on step result: expected a JSON object, got %s",
+            METADATA_HEADER,
+            type(metadata).__name__,
+        )
+        return {}
+    return metadata
 
 
 class StepResult(Mapping):
@@ -228,13 +314,31 @@ def build_request(
 ) -> tuple[str, bytes]:
     """Validate and encode one execute_step call into `(metadata_header, zip_body)`.
 
-    Validation mirrors the server's own checks so a malformed request fails locally rather than
+    Validation mirrors the limits the API enforces so a malformed request fails locally rather than
     after a full upload. A table no param references is only warned about: passing a previous
     step's whole `.data` map is the intended way to chain calls, and a step can return more
     tables than the next one consumes.
     """
+    if (
+        not isinstance(func_name, str)
+        or not 1 <= len(func_name) <= MAX_FUNC_NAME_LENGTH
+    ):
+        raise ValueError(
+            f"func_name must be a string of 1 to {MAX_FUNC_NAME_LENGTH} characters, got "
+            f"{func_name!r}"
+        )
+    if job_timeout_seconds is not None and job_timeout_seconds <= 0:
+        raise ValueError(
+            f"job_timeout_seconds must be positive, got {job_timeout_seconds!r}"
+        )
+
     tables = {key: to_arrow(value) for key, value in (data or {}).items()}
     _validate_member_names(tables)
+    if len(tables) > MAX_MEMBERS:
+        raise ValueError(
+            f"data holds {len(tables)} tables, over the {MAX_MEMBERS} the server accepts. Send "
+            f"fewer tables per request."
+        )
 
     refs = _collect_refs(params)
     missing = refs - set(tables)
@@ -256,4 +360,13 @@ def build_request(
     }
     if job_timeout_seconds is not None:
         metadata["job_options"] = {"timeout_seconds": job_timeout_seconds}
-    return _encode_metadata(metadata), _pack(tables)
+    header = _encode_metadata(metadata)
+
+    body = _pack(tables)
+    if len(body) > MAX_BODY_BYTES:
+        raise ValueError(
+            f"the request body is {len(body)} bytes, over the {MAX_BODY_BYTES}-byte limit the "
+            f"server accepts. Split the request into smaller batches (fewer ids, a shorter "
+            f"history)."
+        )
+    return header, body

--- a/nixtla/steps.py
+++ b/nixtla/steps.py
@@ -49,6 +49,10 @@ MAX_MEMBERS = 512
 MAX_METADATA_DEPTH = 32
 MAX_FUNC_NAME_LENGTH = 128
 
+# The zip format's minimum timestamp, stamped on every member so one data map always serializes to
+# the same bytes. See `_pack`.
+_ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
+
 
 def ref(key: str) -> dict[str, str]:
     """Build the params envelope naming a table in the data map.
@@ -115,19 +119,20 @@ def _validate_member_names(names: Iterable[str]) -> None:
             raise ValueError(f"unsafe data key: {name!r} (must be a bare name)")
 
 
-def _normalize_pandas_index(obj: Any) -> Any:
-    """Fold a pandas index into columns, or drop it, so it never reaches arrow as one.
+def _normalize_pandas_index(obj: Any, key: Optional[str] = None) -> Any:
+    """Drop a pandas index that carries no meaning, and refuse one whose meaning is ambiguous.
 
-    Arrow serializes any non-default index as a column, which is how an ordinary filtered frame
-    (`df[df.y > 1]` leaves a non-contiguous index) grows a phantom `__index_level_0__` that TSMP
-    then rebuilds the resource around. A named index is folded into a real column instead of being
-    discarded: it usually holds the id or timestamp the caller means to send, and dropping it
-    silently would cost them the column. Anything else is positional bookkeeping and is dropped.
+    Arrow serializes any non-default index as a column, so a filtered frame would otherwise send a
+    phantom `__index_level_0__`. This endpoint serializes the whole frame, so the exact column set
+    is what the step runs on.
 
-    A no-op for non-pandas input, so polars and arrow reach `to_arrow` untouched.
+    A named level is therefore rejected rather than guessed at: the name says the values matter but
+    not whether they should travel as a column, and guessing either fabricates one or loses one. An
+    unnamed index makes no such claim and is dropped.
+
+    A no-op for non-pandas input.
     """
-    # Imported here rather than at module scope only to keep pandas out of this module's import
-    # graph; it is a hard dependency of the SDK, so this always resolves.
+    # Local import to keep pandas out of this module's import graph; it is a hard SDK dependency.
     import pandas as pd
 
     if not isinstance(obj, pd.DataFrame):
@@ -136,23 +141,36 @@ def _normalize_pandas_index(obj: Any) -> Any:
     if isinstance(index, pd.RangeIndex) and index.start == 0 and index.step == 1:
         # What arrow already stores as metadata rather than as a column; nothing to do.
         return obj
-    return obj.reset_index(drop=all(name is None for name in index.names))
+    named = [name for name in index.names if name is not None]
+    if named:
+        where = f"data[{key!r}]" if key is not None else "a data value"
+        raise ValueError(
+            f"{where} has a named index level {named[0]!r}, so it is unclear whether those values "
+            f"should be sent as a column. Call .reset_index() to send them, or "
+            f".reset_index(drop=True) to discard them."
+        )
+    return obj.reset_index(drop=True)
 
 
-def to_arrow(obj: Any) -> pa.Table:
+def to_arrow(obj: Any, key: Optional[str] = None) -> pa.Table:
     """Coerce a supported table-like object to a `pyarrow.Table`.
 
     A `pa.Table` is returned unchanged so that a table received from a previous step keeps its
     schema metadata. pandas and polars frames go through narwhals, which is already a hard
-    dependency and reaches arrow in one hop; the rest of the client converts via utilsforecast.
+    dependency and reaches arrow in one hop.
 
     A pandas index is never sent as data -- see `_normalize_pandas_index`.
+
+    Args:
+        obj: The table-like object to convert.
+        key (str, optional): The `data` key `obj` came from, used only to point error messages at
+            the offending entry. Defaults to None.
     """
     if isinstance(obj, pa.Table):
         return obj
 
     try:
-        frame = nw.from_native(_normalize_pandas_index(obj), eager_only=True)
+        frame = nw.from_native(_normalize_pandas_index(obj, key), eager_only=True)
     except TypeError as exc:
         raise TypeError(
             "execute_step data values must be pyarrow Tables or eager pandas/polars DataFrames, "
@@ -164,14 +182,19 @@ def to_arrow(obj: Any) -> pa.Table:
 def _pack(tables: dict[str, pa.Table]) -> bytes:
     """Serialize each table to a `<key>.parquet` member and zip them.
 
-    Members are written in sorted order so the same data map always produces the same bytes.
+    Byte-for-byte reproducible: members are written in sorted order, and each carries `_ZIP_EPOCH`.
+    A bare name would make `writestr` stamp `time.localtime()` into the member header, so one data
+    map would serialize differently from one second to the next.
     """
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for key in sorted(tables):
             member = io.BytesIO()
             pq.write_table(tables[key], member)
-            zf.writestr(key + _PARQUET_SUFFIX, member.getvalue())
+            info = zipfile.ZipInfo(key + _PARQUET_SUFFIX, date_time=_ZIP_EPOCH)
+            # Not inherited from the ZipFile when a ZipInfo is passed.
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, member.getvalue())
     return buf.getvalue()
 
 
@@ -315,9 +338,12 @@ def build_request(
     """Validate and encode one execute_step call into `(metadata_header, zip_body)`.
 
     Validation mirrors the limits the API enforces so a malformed request fails locally rather than
-    after a full upload. A table no param references is only warned about: passing a previous
-    step's whole `.data` map is the intended way to chain calls, and a step can return more
-    tables than the next one consumes.
+    after a full upload, and runs cheapest-first: whatever `params` alone decides is settled before
+    any table is converted, so a bad reference costs no arrow work.
+
+    Only referenced tables are packed. The API ignores the rest, so uploading them would spend
+    bandwidth and body-size budget for nothing -- which makes chaining on a previous step's whole
+    `.data` map free.
     """
     if (
         not isinstance(func_name, str)
@@ -332,27 +358,26 @@ def build_request(
             f"job_timeout_seconds must be positive, got {job_timeout_seconds!r}"
         )
 
-    tables = {key: to_arrow(value) for key, value in (data or {}).items()}
-    _validate_member_names(tables)
-    if len(tables) > MAX_MEMBERS:
+    # Bounds the recursive `_collect_refs` below, so params nested past the limit (or referring to
+    # themselves) raise a ValueError rather than a RecursionError.
+    _check_metadata_depth(params)
+    refs = _collect_refs(params)
+
+    supplied = data or {}
+    _validate_member_names(supplied)
+    if len(supplied) > MAX_MEMBERS:
         raise ValueError(
-            f"data holds {len(tables)} tables, over the {MAX_MEMBERS} the server accepts. Send "
+            f"data holds {len(supplied)} tables, over the {MAX_MEMBERS} the server accepts. Send "
             f"fewer tables per request."
         )
-
-    refs = _collect_refs(params)
-    missing = refs - set(tables)
+    missing = refs - set(supplied)
     if missing:
         raise ValueError(
             f"params reference data keys that were not supplied: {sorted(missing)}; "
-            f"supplied: {sorted(tables)}"
+            f"supplied: {sorted(supplied)}"
         )
-    unused = set(tables) - refs
-    if unused:
-        logger.warning(
-            "data contains tables no param references: %s; they will be uploaded and ignored",
-            sorted(unused),
-        )
+
+    tables = {key: to_arrow(supplied[key], key) for key in refs}
 
     metadata: dict[str, Any] = {
         "func_name": func_name,

--- a/nixtla/steps.py
+++ b/nixtla/steps.py
@@ -8,8 +8,8 @@ header is metadata, so there is exactly one place to look for each.
 Nothing here understands TSMP semantics. Tables returned by the server carry their resource
 identity in arrow schema metadata, and this module passes that through untouched, which is what
 makes chaining one step's output into the next lossless. That is also why this endpoint needs
-pyarrow at all, and hence the `nixtla[steps]` extra: a pandas round-trip drops schema metadata,
-so a chained call would silently misread the previous step's output as an untyped table.
+pyarrow: a pandas round-trip drops schema metadata, so a chained call would silently misread
+the previous step's output as an untyped table.
 """
 
 import io
@@ -20,9 +20,12 @@ from collections.abc import Iterable, Mapping
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any, Optional
 
+import narwhals as nw
+import pyarrow as pa
+import pyarrow.parquet as pq
+
 if TYPE_CHECKING:
     import pandas as pd
-    import pyarrow as pa
 
 __all__ = ["StepResult", "ref"]
 
@@ -37,20 +40,6 @@ _REF_KEY = "data_ref"
 # rejects anything larger with 431 and deliberately does not spill metadata into the body, so the
 # client checks the same budget to fail before uploading rather than after.
 HEADER_BUDGET = 8192
-
-_PYARROW_HINT = (
-    "execute_step requires pyarrow. Install it with: pip install 'nixtla[steps]'"
-)
-
-
-def _require_pyarrow() -> tuple[Any, Any]:
-    """Import pyarrow on demand so the rest of the SDK stays installable without it."""
-    try:
-        import pyarrow as pa  # noqa: F401
-        import pyarrow.parquet as pq  # noqa: F401
-    except ImportError as exc:  # pragma: no cover - exercised via the error path only
-        raise ImportError(_PYARROW_HINT) from exc
-    return pa, pq
 
 
 def ref(key: str) -> dict[str, str]:
@@ -107,18 +96,15 @@ def _validate_member_names(names: Iterable[str]) -> None:
             raise ValueError(f"unsafe data key: {name!r} (must be a bare name)")
 
 
-def to_arrow(obj: Any) -> "pa.Table":
+def to_arrow(obj: Any) -> pa.Table:
     """Coerce a supported table-like object to a `pyarrow.Table`.
 
     A `pa.Table` is returned unchanged so that a table received from a previous step keeps its
     schema metadata. pandas and polars frames go through narwhals, which is already a hard
     dependency and reaches arrow in one hop; the rest of the client converts via utilsforecast.
     """
-    pa, _ = _require_pyarrow()
     if isinstance(obj, pa.Table):
         return obj
-
-    import narwhals as nw
 
     try:
         frame = nw.from_native(obj, eager_only=True)
@@ -130,12 +116,11 @@ def to_arrow(obj: Any) -> "pa.Table":
     return frame.to_arrow()
 
 
-def _pack(tables: dict[str, "pa.Table"]) -> bytes:
+def _pack(tables: dict[str, pa.Table]) -> bytes:
     """Serialize each table to a `<key>.parquet` member and zip them.
 
     Members are written in sorted order so the same data map always produces the same bytes.
     """
-    _, pq = _require_pyarrow()
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for key in sorted(tables):
@@ -145,10 +130,9 @@ def _pack(tables: dict[str, "pa.Table"]) -> bytes:
     return buf.getvalue()
 
 
-def _unpack(body: bytes) -> dict[str, "pa.Table"]:
+def _unpack(body: bytes) -> dict[str, pa.Table]:
     """Parse a response archive back into a data map keyed the way the caller will reference it."""
-    _, pq = _require_pyarrow()
-    tables: dict[str, "pa.Table"] = {}
+    tables: dict[str, pa.Table] = {}
     with zipfile.ZipFile(io.BytesIO(body)) as zf:
         for name in zf.namelist():
             if not name.endswith(_PARQUET_SUFFIX):
@@ -201,11 +185,11 @@ class StepResult(Mapping):
             envelope, and a `profile` of the output when the result is a dataframe.
     """
 
-    def __init__(self, *, data: dict[str, "pa.Table"], metadata: dict[str, Any]):
+    def __init__(self, *, data: dict[str, pa.Table], metadata: dict[str, Any]):
         self.data = data
         self.metadata = metadata
 
-    def __getitem__(self, key: str) -> "pa.Table":
+    def __getitem__(self, key: str) -> pa.Table:
         return self.data[key]
 
     def __iter__(self):

--- a/nixtla/steps.py
+++ b/nixtla/steps.py
@@ -7,35 +7,43 @@ header is metadata, so there is exactly one place to look for each.
 
 Nothing here understands TSMP semantics. Tables returned by the server carry their resource
 identity in arrow schema metadata, and this module passes that through untouched, which is what
-makes chaining one step's output into the next lossless. That is also why pyarrow is required
-rather than optional: a pandas round-trip drops schema metadata, so a chained call would silently
-misread the previous step's output as an untyped table.
+makes chaining one step's output into the next lossless. That is also why this endpoint needs
+pyarrow at all, and hence the `nixtla[steps]` extra: a pandas round-trip drops schema metadata,
+so a chained call would silently misread the previous step's output as an untyped table.
 """
 
 import io
 import json
+import logging
 import zipfile
+from collections.abc import Iterable, Mapping
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
 
+__all__ = ["StepResult", "ref"]
+
+logger = logging.getLogger(__name__)
+
 METADATA_HEADER = "nixtla-metadata"
 CONTENT_TYPE = "application/zip"
-PARQUET_SUFFIX = ".parquet"
-REF_KEY = "data_ref"
+_PARQUET_SUFFIX = ".parquet"
+_REF_KEY = "data_ref"
 
 # Tightest common proxy limit (nginx large_client_header_buffers 8k, CloudFront 8k). The server
 # rejects anything larger with 431 and deliberately does not spill metadata into the body, so the
 # client checks the same budget to fail before uploading rather than after.
 HEADER_BUDGET = 8192
 
-_PYARROW_HINT = "submit_execute_step_job requires pyarrow. Install it with: pip install 'nixtla[steps]'"
+_PYARROW_HINT = (
+    "execute_step requires pyarrow. Install it with: pip install 'nixtla[steps]'"
+)
 
 
-def _require_pyarrow():
+def _require_pyarrow() -> tuple[Any, Any]:
     """Import pyarrow on demand so the rest of the SDK stays installable without it."""
     try:
         import pyarrow as pa  # noqa: F401
@@ -54,26 +62,33 @@ def ref(key: str) -> dict[str, str]:
     Returns:
         dict: `{"data_ref": key}`, the envelope `params` uses to reference a table.
     """
-    return {REF_KEY: key}
+    return {_REF_KEY: key}
 
 
-def collect_refs(obj: Any) -> set[str]:
-    """Every `data_ref` in a params tree, so a bad reference is caught before uploading."""
+def _collect_refs(obj: Any) -> set[str]:
+    """Every `data_ref` in a params tree, so a bad reference is caught before uploading.
+
+    An envelope's siblings are still walked: a param can hold both a `data_ref` and nested
+    params that reference further tables, and missing one of those would reject a valid call.
+    """
+    refs: set[str] = set()
     if isinstance(obj, dict):
-        if REF_KEY in obj:
-            key = obj[REF_KEY]
+        if _REF_KEY in obj:
+            key = obj[_REF_KEY]
             if not isinstance(key, str):
                 raise ValueError(
-                    f"{REF_KEY} must be a string, got {type(key).__name__}"
+                    f"{_REF_KEY} must be a string, got {type(key).__name__}"
                 )
-            return {key}
-        return set().union(*(collect_refs(v) for v in obj.values())) if obj else set()
-    if isinstance(obj, (list, tuple)):
-        return set().union(*(collect_refs(v) for v in obj)) if obj else set()
-    return set()
+            refs.add(key)
+        for value in obj.values():
+            refs |= _collect_refs(value)
+    elif isinstance(obj, (list, tuple)):
+        for value in obj:
+            refs |= _collect_refs(value)
+    return refs
 
 
-def validate_member_names(names: Iterable[str]) -> None:
+def _validate_member_names(names: Iterable[str]) -> None:
     """Require every data-map key to be a bare name.
 
     Keys become archive member names, so a nested or absolute path would be a traversal attempt.
@@ -96,8 +111,8 @@ def to_arrow(obj: Any) -> "pa.Table":
     """Coerce a supported table-like object to a `pyarrow.Table`.
 
     A `pa.Table` is returned unchanged so that a table received from a previous step keeps its
-    schema metadata. pandas and polars frames go through narwhals, the compatibility layer the rest
-    of the SDK already uses.
+    schema metadata. pandas and polars frames go through narwhals, which is already a hard
+    dependency and reaches arrow in one hop; the rest of the client converts via utilsforecast.
     """
     pa, _ = _require_pyarrow()
     if isinstance(obj, pa.Table):
@@ -115,7 +130,7 @@ def to_arrow(obj: Any) -> "pa.Table":
     return frame.to_arrow()
 
 
-def pack(tables: dict[str, "pa.Table"]) -> bytes:
+def _pack(tables: dict[str, "pa.Table"]) -> bytes:
     """Serialize each table to a `<key>.parquet` member and zip them.
 
     Members are written in sorted order so the same data map always produces the same bytes.
@@ -126,33 +141,37 @@ def pack(tables: dict[str, "pa.Table"]) -> bytes:
         for key in sorted(tables):
             member = io.BytesIO()
             pq.write_table(tables[key], member)
-            zf.writestr(key + PARQUET_SUFFIX, member.getvalue())
+            zf.writestr(key + _PARQUET_SUFFIX, member.getvalue())
     return buf.getvalue()
 
 
-def unpack(body: bytes) -> dict[str, "pa.Table"]:
+def _unpack(body: bytes) -> dict[str, "pa.Table"]:
     """Parse a response archive back into a data map keyed the way the caller will reference it."""
     _, pq = _require_pyarrow()
     tables: dict[str, "pa.Table"] = {}
     with zipfile.ZipFile(io.BytesIO(body)) as zf:
         for name in zf.namelist():
-            if not name.endswith(PARQUET_SUFFIX):
+            if not name.endswith(_PARQUET_SUFFIX):
+                # Not a table; the archive is documented to hold nothing else, so say so
+                # rather than returning a quietly incomplete result.
+                logger.warning("ignoring unexpected member %r in step result", name)
                 continue
-            tables[name[: -len(PARQUET_SUFFIX)]] = pq.read_table(
+            tables[name[: -len(_PARQUET_SUFFIX)]] = pq.read_table(
                 io.BytesIO(zf.read(name))
             )
     return tables
 
 
-def encode_metadata(metadata: dict[str, Any]) -> str:
+def _encode_metadata(metadata: dict[str, Any]) -> str:
     """Serialize the request metadata, refusing anything that will not fit the header.
 
-    `json.dumps` defaults to `ensure_ascii=True`, so the value is pure ASCII and therefore safe as
-    an HTTP header. Metadata is never moved into the body: the archive holds tables and nothing
-    else, so an oversized header is a bad request rather than something to route around.
+    `json.dumps` defaults to `ensure_ascii=True`, so the value is pure ASCII -- one byte per
+    character, and safe as an HTTP header. Metadata is never moved into the body: the archive
+    holds tables and nothing else, so an oversized header is a bad request rather than
+    something to route around.
     """
     payload = json.dumps(metadata)
-    size = len(payload.encode())
+    size = len(payload)
     if size > HEADER_BUDGET:
         raise ValueError(
             f"{METADATA_HEADER} would be {size} bytes, over the {HEADER_BUDGET}-byte budget. "
@@ -162,16 +181,17 @@ def encode_metadata(metadata: dict[str, Any]) -> str:
     return payload
 
 
-def decode_metadata(headers: Any) -> dict[str, Any]:
-    """Read the response metadata header. HTTP header names are not case-sensitive."""
-    for key, value in dict(headers).items():
-        if key.lower() == METADATA_HEADER:
-            return json.loads(value)
-    return {}
+def _decode_metadata(headers: Mapping[str, str]) -> dict[str, Any]:
+    """Read the response metadata header, or `{}` when the server sent none."""
+    value = headers.get(METADATA_HEADER)
+    return json.loads(value) if value else {}
 
 
-class StepResult:
+class StepResult(Mapping):
     """Result of an `execute_step` job.
+
+    A read-only mapping of table name to `pyarrow.Table`, so `res["result"]`, `len(res)`,
+    iteration and `dict(res)` all work.
 
     Attributes:
         data (dict): Result tables keyed by name, as `pyarrow.Table`. Pass this straight back as
@@ -188,11 +208,11 @@ class StepResult:
     def __getitem__(self, key: str) -> "pa.Table":
         return self.data[key]
 
-    def __contains__(self, key: str) -> bool:
-        return key in self.data
+    def __iter__(self):
+        return iter(self.data)
 
-    def keys(self):
-        return self.data.keys()
+    def __len__(self) -> int:
+        return len(self.data)
 
     def to_pandas(self) -> dict[str, "pd.DataFrame"]:
         """Convert every result table to a pandas DataFrame.
@@ -211,9 +231,9 @@ class StepResult:
         return f"StepResult(func_name={func_name!r}, data={{{shapes}}})"
 
 
-def build_result(headers: Any, body: bytes) -> StepResult:
+def build_result(headers: Mapping[str, str], body: bytes) -> StepResult:
     """Assemble a `StepResult` from a raw `(headers, body)` response pair."""
-    return StepResult(data=unpack(body), metadata=decode_metadata(headers))
+    return StepResult(data=_unpack(body), metadata=_decode_metadata(headers))
 
 
 def build_request(
@@ -225,12 +245,14 @@ def build_request(
     """Validate and encode one execute_step call into `(metadata_header, zip_body)`.
 
     Validation mirrors the server's own checks so a malformed request fails locally rather than
-    after a full upload.
+    after a full upload. A table no param references is only warned about: passing a previous
+    step's whole `.data` map is the intended way to chain calls, and a step can return more
+    tables than the next one consumes.
     """
     tables = {key: to_arrow(value) for key, value in (data or {}).items()}
-    validate_member_names(tables)
+    _validate_member_names(tables)
 
-    refs = collect_refs(params)
+    refs = _collect_refs(params)
     missing = refs - set(tables)
     if missing:
         raise ValueError(
@@ -239,9 +261,9 @@ def build_request(
         )
     unused = set(tables) - refs
     if unused:
-        raise ValueError(
-            f"data contains tables no param references: {sorted(unused)}. "
-            f"They would be uploaded and ignored."
+        logger.warning(
+            "data contains tables no param references: %s; they will be uploaded and ignored",
+            sorted(unused),
         )
 
     metadata: dict[str, Any] = {
@@ -250,4 +272,4 @@ def build_request(
     }
     if job_timeout_seconds is not None:
         metadata["job_options"] = {"timeout_seconds": job_timeout_seconds}
-    return encode_metadata(metadata), pack(tables)
+    return _encode_metadata(metadata), _pack(tables)

--- a/nixtla_tests/nixtla_client/test_async_jobs.py
+++ b/nixtla_tests/nixtla_client/test_async_jobs.py
@@ -786,6 +786,185 @@ def test_submit_job_threads_job_timeout_seconds(
     assert "job_options" not in payloads[1]
 
 
+@pytest.mark.parametrize(
+    "method_name, endpoint, make_call_kwargs, model_params", SUBMIT_JOB_CASES
+)
+@pytest.mark.parametrize("bad_timeout", [0, -1])
+def test_submit_job_rejects_a_non_positive_job_timeout(
+    monkeypatch, method_name, endpoint, make_call_kwargs, model_params, bad_timeout
+):
+    """The server refuses these, so the client should not spend a round-trip finding out."""
+
+    def boom(*args, **kwargs):
+        raise AssertionError("validation should fail before any HTTP call")
+
+    _stub_model_params(monkeypatch, model_params)
+    monkeypatch.setattr(NixtlaClient, "_submit_job", boom)
+
+    with pytest.raises(ValueError, match="job_timeout_seconds must be positive"):
+        getattr(_client(), method_name)(
+            **make_call_kwargs(), job_timeout_seconds=bad_timeout
+        )
+
+
+# ---------------------------------------------------------------------------
+# job_timeout_seconds on the async forecast/cross_validation paths
+# ---------------------------------------------------------------------------
+
+
+def _capture_submitted_payloads(monkeypatch, h=5):
+    """Record every payload reaching `_submit_job`, with polling stubbed out.
+
+    The stubbed result is shaped per endpoint because forecast and cross_validation parse their
+    responses differently; these tests only assert on what was *sent*, but the call still has to
+    return without blowing up in `parse_result`.
+    """
+    payloads = []
+
+    def fake_submit_job(self, client, endpoint, payload, multithreaded_compress=True):
+        payloads.append((endpoint, payload))
+        return "job-1"
+
+    def fake_poll_job(self, client, endpoint, job_id, poll_interval, poll_timeout):
+        if endpoint == "v2/cross_validation":
+            n = len(payloads[-1][1]["series"]["y"])
+            result = {
+                "idxs": list(range(n - h, n)),
+                "sizes": [h],
+                "mean": list(range(h)),
+                "intervals": None,
+            }
+        else:
+            result = {"mean": list(range(h)), "intervals": None, "weights_x": None}
+        return {"status": "succeeded", "result": result}
+
+    monkeypatch.setattr(NixtlaClient, "_submit_job", fake_submit_job)
+    monkeypatch.setattr(NixtlaClient, "_poll_job", fake_poll_job)
+    monkeypatch.setattr(
+        NixtlaClient, "_get_model_params", lambda self, model, freq: (10_000, 12)
+    )
+    return payloads
+
+
+def test_run_async_job_folds_job_options_into_the_payload(monkeypatch):
+    payloads = _capture_submitted_payloads(monkeypatch)
+    client = _client()
+
+    original = {"idx": 0}
+    client._run_async_job(
+        MagicMock(), "v2/forecast", original, 0, 1, job_timeout_seconds=300
+    )
+
+    assert payloads[0][1]["job_options"] == {"timeout_seconds": 300}
+    # The caller's dict is reused to derive other requests, so it must not be mutated.
+    assert original == {"idx": 0}
+
+
+def test_run_async_job_omits_job_options_when_unset(monkeypatch):
+    payloads = _capture_submitted_payloads(monkeypatch)
+    _client()._run_async_job(MagicMock(), "v2/forecast", {"idx": 0}, 0, 1)
+    assert "job_options" not in payloads[0][1]
+
+
+def test_make_partitioned_requests_forwards_the_job_timeout():
+    client = _client()
+    seen = []
+
+    def fake_run_async_job(
+        client,
+        endpoint,
+        payload,
+        poll_interval,
+        poll_timeout,
+        multithreaded_compress=True,
+        job_timeout_seconds=None,
+    ):
+        seen.append(job_timeout_seconds)
+        return {"mean": [payload["idx"]], "intervals": None, "weights_x": None}
+
+    client._run_async_job = fake_run_async_job
+    client._make_partitioned_requests(
+        MagicMock(),
+        "v2/forecast",
+        [{"idx": i} for i in range(3)],
+        _is_async_job=True,
+        _poll_interval=1,
+        _poll_timeout=2,
+        _job_timeout_seconds=300,
+    )
+
+    # Per job, not per call: every partition is its own job and gets the full budget.
+    assert seen == [300, 300, 300]
+
+
+def test_forecast_async_job_carries_the_job_timeout(monkeypatch):
+    payloads = _capture_submitted_payloads(monkeypatch)
+
+    _client().forecast(df=_small_df(), h=5, job_timeout_seconds=300, _is_async_job=True)
+
+    assert payloads[0][1]["job_options"] == {"timeout_seconds": 300}
+
+
+def test_forecast_add_history_applies_the_timeout_to_both_jobs(monkeypatch):
+    payloads = _capture_submitted_payloads(monkeypatch)
+
+    _client().forecast(
+        df=_small_df(),
+        h=5,
+        add_history=True,
+        job_timeout_seconds=300,
+        _is_async_job=True,
+    )
+
+    # The forecast job and the in-sample cross_validation job are separate jobs.
+    assert [endpoint for endpoint, _ in payloads] == [
+        "v2/forecast",
+        "v2/cross_validation",
+    ]
+    assert all(p["job_options"] == {"timeout_seconds": 300} for _, p in payloads)
+
+
+def test_forecast_partitioned_async_job_carries_the_job_timeout(monkeypatch):
+    payloads = _capture_submitted_payloads(monkeypatch)
+
+    _client().forecast(
+        df=_multi_series_df(n_series=2),
+        h=5,
+        num_partitions=2,
+        job_timeout_seconds=300,
+        _is_async_job=True,
+    )
+
+    assert len(payloads) == 2
+    assert all(p["job_options"] == {"timeout_seconds": 300} for _, p in payloads)
+
+
+def test_cross_validation_async_job_carries_the_job_timeout(monkeypatch):
+    payloads = _capture_submitted_payloads(monkeypatch)
+
+    _client().cross_validation(
+        df=_small_df(), h=5, job_timeout_seconds=300, _is_async_job=True
+    )
+
+    assert payloads[0][1]["job_options"] == {"timeout_seconds": 300}
+
+
+@pytest.mark.parametrize("method_name", ["forecast", "cross_validation"])
+def test_job_timeout_without_async_job_raises(method_name):
+    # A synchronous request creates no job, so silently ignoring the value would be worse.
+    with pytest.raises(ValueError, match="only applies when this call runs its work"):
+        getattr(_client(), method_name)(df=_small_df(), h=5, job_timeout_seconds=300)
+
+
+@pytest.mark.parametrize("method_name", ["forecast", "cross_validation"])
+@pytest.mark.parametrize("bad_timeout", [0, -1])
+def test_forecast_and_cv_reject_a_non_positive_job_timeout(method_name, bad_timeout):
+    with pytest.raises(ValueError, match="job_timeout_seconds must be positive"):
+        getattr(_client(), method_name)(
+            df=_small_df(), h=5, job_timeout_seconds=bad_timeout, _is_async_job=True
+        )
+
+
 # ---------------------------------------------------------------------------
 # num_partitions + async job fan-out (local pandas/polars DataFrames)
 # ---------------------------------------------------------------------------
@@ -796,7 +975,13 @@ def test_make_partitioned_requests_dispatches_async_jobs():
     calls = []
 
     def fake_run_async_job(
-        client, endpoint, payload, poll_interval, poll_timeout, multithreaded_compress=True
+        client,
+        endpoint,
+        payload,
+        poll_interval,
+        poll_timeout,
+        multithreaded_compress=True,
+        job_timeout_seconds=None,
     ):
         calls.append((endpoint, poll_interval, poll_timeout, multithreaded_compress))
         return {"mean": [payload["idx"]], "intervals": None, "weights_x": None}
@@ -824,7 +1009,13 @@ def test_make_partitioned_requests_propagates_async_job_error():
     client = _client()
 
     def fake_run_async_job(
-        client, endpoint, payload, poll_interval, poll_timeout, multithreaded_compress=True
+        client,
+        endpoint,
+        payload,
+        poll_interval,
+        poll_timeout,
+        multithreaded_compress=True,
+        job_timeout_seconds=None,
     ):
         if payload["idx"] == 1:
             raise AsyncJobError(job_id="fc-bad", error="boom")
@@ -852,7 +1043,14 @@ def test_forecast_num_partitions_with_async_job(monkeypatch):
         return 100, 12
 
     def fake_run_async_job(
-        self, client, endpoint, payload, poll_interval, poll_timeout, multithreaded_compress=True
+        self,
+        client,
+        endpoint,
+        payload,
+        poll_interval,
+        poll_timeout,
+        multithreaded_compress=True,
+        job_timeout_seconds=None,
     ):
         calls.append(endpoint)
         return {"mean": list(range(h)), "intervals": None, "weights_x": None}
@@ -882,7 +1080,14 @@ def test_cross_validation_num_partitions_with_async_job(monkeypatch):
         return 10_000, 12
 
     def fake_run_async_job(
-        self, client, endpoint, payload, poll_interval, poll_timeout, multithreaded_compress=True
+        self,
+        client,
+        endpoint,
+        payload,
+        poll_interval,
+        poll_timeout,
+        multithreaded_compress=True,
+        job_timeout_seconds=None,
     ):
         calls.append(endpoint)
         n = len(payload["series"]["y"])

--- a/nixtla_tests/nixtla_client/test_async_jobs.py
+++ b/nixtla_tests/nixtla_client/test_async_jobs.py
@@ -141,11 +141,12 @@ def test_run_async_job_unexpected_status():
         )
 
 
-def test_run_async_job_timeout():
+def test_run_async_job_timeout(monkeypatch):
     client = _client()
     fake_make_request, fake_get_request, _ = _polling_stubs([{"status": "running"}])
     client._make_request = fake_make_request
     client._get_request = fake_get_request
+    monkeypatch.setattr(NixtlaClient, "_cancel_job", lambda self, client, job_id: None)
 
     with pytest.raises(AsyncJobTimeoutError) as excinfo:
         client._run_async_job(
@@ -153,6 +154,79 @@ def test_run_async_job_timeout():
         )
 
     assert excinfo.value.job_id == "fc-abc123"
+
+
+def test_run_async_job_cancels_the_job_on_timeout(monkeypatch):
+    """`_run_async_job` never surfaces the job_id, so a client-side timeout must
+    cancel the job here or nobody ever can."""
+    client = _client()
+    fake_make_request, fake_get_request, _ = _polling_stubs([{"status": "running"}])
+    client._make_request = fake_make_request
+    client._get_request = fake_get_request
+
+    calls = []
+    monkeypatch.setattr(
+        NixtlaClient, "_cancel_job", lambda self, client, job_id: calls.append(job_id)
+    )
+
+    with pytest.raises(AsyncJobTimeoutError):
+        client._run_async_job(
+            MagicMock(), "v2/forecast", {}, poll_interval=0, poll_timeout=0.05
+        )
+
+    assert calls == ["fc-abc123"]
+
+
+@pytest.mark.parametrize(
+    "statuses, expected_error",
+    [
+        ([{"status": "failed", "error": {"detail": "boom"}}], AsyncJobError),
+        ([{"status": "cancelled"}], AsyncJobCancelledError),
+    ],
+    ids=["failed", "cancelled"],
+)
+def test_run_async_job_does_not_cancel_on_terminal_states(
+    monkeypatch, statuses, expected_error
+):
+    """Failed/cancelled jobs are already terminal -- cancelling them is pointless."""
+    client = _client()
+    fake_make_request, fake_get_request, _ = _polling_stubs(statuses)
+    client._make_request = fake_make_request
+    client._get_request = fake_get_request
+
+    calls = []
+    monkeypatch.setattr(
+        NixtlaClient, "_cancel_job", lambda self, client, job_id: calls.append(job_id)
+    )
+
+    with pytest.raises(expected_error):
+        client._run_async_job(
+            MagicMock(), "v2/forecast", {}, poll_interval=0, poll_timeout=5
+        )
+
+    assert calls == []
+
+
+def test_run_async_job_timeout_survives_a_failing_cancel(monkeypatch, caplog):
+    """A failed cancel must be logged, not raised: it would mask the timeout."""
+    client = _client()
+    fake_make_request, fake_get_request, _ = _polling_stubs([{"status": "running"}])
+    client._make_request = fake_make_request
+    client._get_request = fake_get_request
+
+    def fake_cancel_job(self, client, job_id):
+        raise ApiError(status_code=500, body={"detail": "boom"})
+
+    monkeypatch.setattr(NixtlaClient, "_cancel_job", fake_cancel_job)
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(AsyncJobTimeoutError) as excinfo:
+            client._run_async_job(
+                MagicMock(), "v2/forecast", {}, poll_interval=0, poll_timeout=0.05
+            )
+
+    assert excinfo.value.job_id == "fc-abc123"
+    assert "Failed to cancel job fc-abc123" in caplog.text
 
 
 def test_run_async_job_fails_fast_on_non_retriable_poll_error():
@@ -468,6 +542,99 @@ def test_job_wait_raises_after_cancelled_status(monkeypatch):
         job.wait(poll_interval=1, poll_timeout=2)
 
     assert excinfo.value.job_id == "ft-job-1"
+
+
+def _raise(exc):
+    raise exc
+
+
+def _recording_cancel(calls):
+    """A `_cancel_job` stub that records the job ids it was asked to cancel."""
+
+    def fake_cancel_job(self, client, job_id):
+        calls.append(job_id)
+
+    return fake_cancel_job
+
+
+def _timing_out_job(monkeypatch, cancel_job):
+    """A submitted `Job` whose polling always times out, with `_cancel_job` stubbed."""
+    monkeypatch.setattr(
+        NixtlaClient,
+        "_submit_job",
+        lambda self, client, endpoint, payload, multithreaded_compress=True: "ft-job-1",
+    )
+    monkeypatch.setattr(
+        NixtlaClient,
+        "_poll_job",
+        lambda self, client, endpoint, job_id, poll_interval, poll_timeout: _raise(
+            AsyncJobTimeoutError(job_id=job_id, poll_timeout=poll_timeout)
+        ),
+    )
+    monkeypatch.setattr(NixtlaClient, "_cancel_job", cancel_job)
+    return _client().submit_finetune_job(df=_small_df(), freq="D")
+
+
+def test_job_wait_does_not_cancel_on_timeout_by_default(monkeypatch):
+    """`poll_timeout` bounds local polling only, so waiting in short increments
+    and resuming has to leave the job alone."""
+    calls = []
+    job = _timing_out_job(monkeypatch, _recording_cancel(calls))
+
+    for _ in range(2):
+        with pytest.raises(AsyncJobTimeoutError):
+            job.wait(poll_interval=0, poll_timeout=0.01)
+
+    assert calls == []
+    assert job._status is None  # still resumable
+
+
+def test_job_wait_cancels_on_timeout_when_opted_in(monkeypatch):
+    calls = []
+    job = _timing_out_job(monkeypatch, _recording_cancel(calls))
+
+    with pytest.raises(AsyncJobTimeoutError):
+        job.wait(poll_interval=0, poll_timeout=0.01, cancel_on_timeout=True)
+
+    assert calls == ["ft-job-1"]
+    assert job.status == "cancelled"
+
+
+def test_job_wait_cancel_on_timeout_leaves_status_unresolved_if_cancel_fails(
+    monkeypatch, caplog
+):
+    """A cancel that the server rejected must not be cached as `cancelled`;
+    `status` should go back to the server for the truth."""
+
+    def fake_cancel_job(self, client, job_id):
+        raise ApiError(status_code=500, body={"detail": "boom"})
+
+    job = _timing_out_job(monkeypatch, fake_cancel_job)
+    monkeypatch.setattr(
+        NixtlaClient,
+        "_get_job_data",
+        lambda self, client, endpoint, job_id: {"status": "running"},
+    )
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(AsyncJobTimeoutError):
+            job.wait(poll_interval=0, poll_timeout=0.01, cancel_on_timeout=True)
+
+    assert "Failed to cancel job ft-job-1" in caplog.text
+    assert job._status is None
+    assert job.status == "running"
+
+
+def test_job_wait_cancel_on_timeout_inside_context_manager_cancels_once(monkeypatch):
+    """`wait` marks the status terminal, so `__exit__` must not cancel again."""
+    calls = []
+    job = _timing_out_job(monkeypatch, _recording_cancel(calls))
+
+    with pytest.raises(AsyncJobTimeoutError):
+        with job:
+            job.wait(poll_interval=0, poll_timeout=0.01, cancel_on_timeout=True)
+
+    assert calls == ["ft-job-1"]
 
 
 # ---------------------------------------------------------------------------

--- a/nixtla_tests/nixtla_client/test_async_jobs.py
+++ b/nixtla_tests/nixtla_client/test_async_jobs.py
@@ -912,7 +912,7 @@ def test_make_partitioned_requests_forwards_the_job_timeout():
 def test_forecast_async_job_carries_the_job_timeout(monkeypatch):
     payloads = _capture_submitted_payloads(monkeypatch)
 
-    _client().forecast(df=_small_df(), h=5, job_timeout_seconds=300, _is_async_job=True)
+    _client().forecast(df=_small_df(), h=5, _job_timeout_seconds=300, _is_async_job=True)
 
     assert payloads[0][1]["job_options"] == {"timeout_seconds": 300}
 
@@ -924,7 +924,7 @@ def test_forecast_add_history_applies_the_timeout_to_both_jobs(monkeypatch):
         df=_small_df(),
         h=5,
         add_history=True,
-        job_timeout_seconds=300,
+        _job_timeout_seconds=300,
         _is_async_job=True,
     )
 
@@ -943,7 +943,7 @@ def test_forecast_partitioned_async_job_carries_the_job_timeout(monkeypatch):
         df=_multi_series_df(n_series=2),
         h=5,
         num_partitions=2,
-        job_timeout_seconds=300,
+        _job_timeout_seconds=300,
         _is_async_job=True,
     )
 
@@ -955,7 +955,7 @@ def test_cross_validation_async_job_carries_the_job_timeout(monkeypatch):
     payloads = _capture_submitted_payloads(monkeypatch)
 
     _client().cross_validation(
-        df=_small_df(), h=5, job_timeout_seconds=300, _is_async_job=True
+        df=_small_df(), h=5, _job_timeout_seconds=300, _is_async_job=True
     )
 
     assert payloads[0][1]["job_options"] == {"timeout_seconds": 300}
@@ -964,8 +964,8 @@ def test_cross_validation_async_job_carries_the_job_timeout(monkeypatch):
 @pytest.mark.parametrize("method_name", ["forecast", "cross_validation"])
 def test_job_timeout_without_async_job_raises(method_name):
     # A synchronous request creates no job, so silently ignoring the value would be worse.
-    with pytest.raises(ValueError, match="only applies when this call runs its work"):
-        getattr(_client(), method_name)(df=_small_df(), h=5, job_timeout_seconds=300)
+    with pytest.raises(ValueError, match="requires _is_async_job"):
+        getattr(_client(), method_name)(df=_small_df(), h=5, _job_timeout_seconds=300)
 
 
 @pytest.mark.parametrize("method_name", ["forecast", "cross_validation"])
@@ -973,7 +973,7 @@ def test_job_timeout_without_async_job_raises(method_name):
 def test_forecast_and_cv_reject_a_non_positive_job_timeout(method_name, bad_timeout):
     with pytest.raises(ValueError, match="job_timeout_seconds must be positive"):
         getattr(_client(), method_name)(
-            df=_small_df(), h=5, job_timeout_seconds=bad_timeout, _is_async_job=True
+            df=_small_df(), h=5, _job_timeout_seconds=bad_timeout, _is_async_job=True
         )
 
 

--- a/nixtla_tests/nixtla_client/test_async_jobs.py
+++ b/nixtla_tests/nixtla_client/test_async_jobs.py
@@ -575,21 +575,33 @@ def _timing_out_job(monkeypatch, cancel_job):
     return _client().submit_finetune_job(df=_small_df(), freq="D")
 
 
-def test_job_wait_does_not_cancel_on_timeout_by_default(monkeypatch):
-    """`poll_timeout` bounds local polling only, so waiting in short increments
-    and resuming has to leave the job alone."""
+def test_job_wait_cancels_on_timeout_by_default(monkeypatch):
+    """Giving up on a job should stop it consuming server-side compute."""
+    calls = []
+    job = _timing_out_job(monkeypatch, _recording_cancel(calls))
+
+    with pytest.raises(AsyncJobTimeoutError):
+        job.wait(poll_interval=0, poll_timeout=0.01)
+
+    assert calls == ["ft-job-1"]
+    assert job.status == "cancelled"
+
+
+def test_job_wait_leaves_the_job_running_when_opted_out(monkeypatch):
+    """`poll_timeout` bounds local polling only, so `cancel_on_timeout=False`
+    supports waiting in short increments and resuming."""
     calls = []
     job = _timing_out_job(monkeypatch, _recording_cancel(calls))
 
     for _ in range(2):
         with pytest.raises(AsyncJobTimeoutError):
-            job.wait(poll_interval=0, poll_timeout=0.01)
+            job.wait(poll_interval=0, poll_timeout=0.01, cancel_on_timeout=False)
 
     assert calls == []
     assert job._status is None  # still resumable
 
 
-def test_job_wait_cancels_on_timeout_when_opted_in(monkeypatch):
+def test_job_wait_cancels_on_timeout_when_set_explicitly(monkeypatch):
     calls = []
     job = _timing_out_job(monkeypatch, _recording_cancel(calls))
 

--- a/nixtla_tests/nixtla_client/test_distributed_async_wrappers.py
+++ b/nixtla_tests/nixtla_client/test_distributed_async_wrappers.py
@@ -44,7 +44,7 @@ def test_forecast_wrapper_forwards_async_kwargs():
         feature_contributions=False,
         model_parameters=None,
         multivariate=False,
-        job_timeout_seconds=300,
+        _job_timeout_seconds=300,
         _is_async_job=True,
         _poll_interval=7,
         _poll_timeout=42,
@@ -55,7 +55,7 @@ def test_forecast_wrapper_forwards_async_kwargs():
     assert kwargs["_is_async_job"] is True
     assert kwargs["_poll_interval"] == 7
     assert kwargs["_poll_timeout"] == 42
-    assert kwargs["job_timeout_seconds"] == 300
+    assert kwargs["_job_timeout_seconds"] == 300
 
 
 def test_forecast_wrapper_defaults_are_sync():
@@ -123,7 +123,7 @@ def test_cross_validation_wrapper_forwards_async_kwargs():
         model_parameters=None,
         multivariate=False,
         categorical_exog_list=None,
-        job_timeout_seconds=300,
+        _job_timeout_seconds=300,
         _is_async_job=True,
         _poll_interval=7,
         _poll_timeout=42,
@@ -134,4 +134,4 @@ def test_cross_validation_wrapper_forwards_async_kwargs():
     assert kwargs["_is_async_job"] is True
     assert kwargs["_poll_interval"] == 7
     assert kwargs["_poll_timeout"] == 42
-    assert kwargs["job_timeout_seconds"] == 300
+    assert kwargs["_job_timeout_seconds"] == 300

--- a/nixtla_tests/nixtla_client/test_distributed_async_wrappers.py
+++ b/nixtla_tests/nixtla_client/test_distributed_async_wrappers.py
@@ -44,6 +44,7 @@ def test_forecast_wrapper_forwards_async_kwargs():
         feature_contributions=False,
         model_parameters=None,
         multivariate=False,
+        job_timeout_seconds=300,
         _is_async_job=True,
         _poll_interval=7,
         _poll_timeout=42,
@@ -54,6 +55,7 @@ def test_forecast_wrapper_forwards_async_kwargs():
     assert kwargs["_is_async_job"] is True
     assert kwargs["_poll_interval"] == 7
     assert kwargs["_poll_timeout"] == 42
+    assert kwargs["job_timeout_seconds"] == 300
 
 
 def test_forecast_wrapper_defaults_are_sync():
@@ -121,6 +123,7 @@ def test_cross_validation_wrapper_forwards_async_kwargs():
         model_parameters=None,
         multivariate=False,
         categorical_exog_list=None,
+        job_timeout_seconds=300,
         _is_async_job=True,
         _poll_interval=7,
         _poll_timeout=42,
@@ -131,3 +134,4 @@ def test_cross_validation_wrapper_forwards_async_kwargs():
     assert kwargs["_is_async_job"] is True
     assert kwargs["_poll_interval"] == 7
     assert kwargs["_poll_timeout"] == 42
+    assert kwargs["job_timeout_seconds"] == 300

--- a/nixtla_tests/nixtla_client/test_execute_step_job.py
+++ b/nixtla_tests/nixtla_client/test_execute_step_job.py
@@ -22,7 +22,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from nixtla.nixtla_client import ApiError, Job, NixtlaClient
+from nixtla.nixtla_client import ApiError, Job, NixtlaClient, _is_retriable_error
 from nixtla.steps import (
     CONTENT_TYPE,
     HEADER_BUDGET,
@@ -402,16 +402,38 @@ class TestResult:
             _client()._get_job_result_bytes(http_client, "v2/execute_step", "es-1")
         assert exc.value.status_code == 422
 
-    def test_conflict_while_not_ready_is_retried(self, monkeypatch):
-        # The job says succeeded but the zip has not materialized yet: 409 is retriable, and
-        # giving up here would discard work the server has already done and billed.
+    @pytest.mark.parametrize("not_ready_status", [202, 409])
+    def test_a_not_ready_response_raises_a_retriable_error(self, not_ready_status):
+        # Goes through the real status check rather than a hand-made ApiError: the retry above
+        # only helps if `_get_job_result_bytes` actually raises on this status *and*
+        # `_is_retriable_error` accepts what it raised. Together these pin the wire contract.
+        http_client = MagicMock()
+        resp = MagicMock(status_code=not_ready_status, content=b"PK")
+        resp.json.return_value = {"detail": "result not ready, poll again"}
+        http_client.get.return_value = resp
+
+        with pytest.raises(ApiError) as exc:
+            _client()._get_job_result_bytes(http_client, "v2/execute_step", "es-1")
+
+        assert exc.value.status_code == not_ready_status
+        assert _is_retriable_error(exc.value)
+
+    @pytest.mark.parametrize("not_ready_status", [202, 409])
+    def test_not_ready_from_the_result_endpoint_is_retried(
+        self, monkeypatch, not_ready_status
+    ):
+        # The job says succeeded but the zip has not materialized yet: giving up here would
+        # discard work the server has already done and billed. 202 is what current servers
+        # answer, 409 what older ones did, and both must keep the retry going.
         body = _pack({"result": _tagged_table()})
         attempts = []
 
         def flaky_result(self, client, endpoint, job_id):
             attempts.append(job_id)
             if len(attempts) == 1:
-                raise ApiError(status_code=409, body={"detail": "not succeeded"})
+                raise ApiError(
+                    status_code=not_ready_status, body={"detail": "not succeeded"}
+                )
             return {}, body
 
         _stub_submit_binary(monkeypatch)

--- a/nixtla_tests/nixtla_client/test_execute_step_job.py
+++ b/nixtla_tests/nixtla_client/test_execute_step_job.py
@@ -19,12 +19,11 @@ from unittest.mock import MagicMock
 import httpx
 import orjson
 import pandas as pd
+import pyarrow as pa
 import pytest
 
-pa = pytest.importorskip("pyarrow")
-
-from nixtla.nixtla_client import ApiError, Job, NixtlaClient  # noqa: E402
-from nixtla.steps import (  # noqa: E402
+from nixtla.nixtla_client import ApiError, Job, NixtlaClient
+from nixtla.steps import (
     CONTENT_TYPE,
     HEADER_BUDGET,
     METADATA_HEADER,

--- a/nixtla_tests/nixtla_client/test_execute_step_job.py
+++ b/nixtla_tests/nixtla_client/test_execute_step_job.py
@@ -22,7 +22,13 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from nixtla.nixtla_client import ApiError, Job, NixtlaClient, _is_retriable_error
+from nixtla.nixtla_client import (
+    ApiError,
+    AsyncJobTimeoutError,
+    Job,
+    NixtlaClient,
+    _is_retriable_error,
+)
 from nixtla.steps import (
     CONTENT_TYPE,
     HEADER_BUDGET,
@@ -600,10 +606,9 @@ class TestResult:
         assert exc.value.status_code == 422
 
     @pytest.mark.parametrize("not_ready_status", [202, 409])
-    def test_a_not_ready_response_raises_a_retriable_error(self, not_ready_status):
-        # Goes through the real status check rather than a hand-made ApiError: the retry above
-        # only helps if `_get_job_result_bytes` actually raises on this status *and*
-        # `_is_retriable_error` accepts what it raised. Together these pin the wire contract.
+    def test_a_not_ready_response_raises_with_that_status(self, not_ready_status):
+        # Goes through the real status check rather than a hand-made ApiError, so this pins the
+        # wire contract the waiting loop below is written against.
         http_client = MagicMock()
         resp = MagicMock(status_code=not_ready_status, content=b"PK")
         resp.json.return_value = {"detail": "result not ready, poll again"}
@@ -613,15 +618,20 @@ class TestResult:
             _client()._get_job_result_bytes(http_client, "v2/execute_step", "es-1")
 
         assert exc.value.status_code == not_ready_status
-        assert _is_retriable_error(exc.value)
+
+    def test_not_ready_is_not_classified_as_a_retriable_failure(self):
+        # 202 is a success status: waiting for a result is a polling state, not a failure, so it
+        # must not go through the machinery that logs every attempt as an error.
+        assert not _is_retriable_error(ApiError(status_code=202, body={}))
+        # 409 predates this and still serves other endpoints.
+        assert _is_retriable_error(ApiError(status_code=409, body={}))
 
     @pytest.mark.parametrize("not_ready_status", [202, 409])
-    def test_not_ready_from_the_result_endpoint_is_retried(
+    def test_not_ready_from_the_result_endpoint_is_waited_out(
         self, monkeypatch, not_ready_status
     ):
-        # The job says succeeded but the zip has not materialized yet: giving up here would
-        # discard work the server has already done and billed. 202 is what current servers
-        # answer, 409 what older ones did, and both must keep the retry going.
+        # The job says succeeded but the payload has not been served yet: giving up here would
+        # discard work the server has already done and billed.
         body = _pack({"result": _tagged_table()})
         attempts = []
 
@@ -641,12 +651,103 @@ class TestResult:
         )
         monkeypatch.setattr(NixtlaClient, "_get_job_result_bytes", flaky_result)
 
-        res = (
-            _client(retry_interval=0)
-            .submit_execute_step_job(**_call_kwargs())
-            .wait(poll_interval=0)
-        )
+        res = _client().submit_execute_step_job(**_call_kwargs()).wait(poll_interval=0)
 
+        assert len(attempts) == 2
+        assert res["result"].num_rows == 3
+
+    def test_waiting_for_a_result_logs_no_errors(self, monkeypatch, caplog):
+        """A successful wait must not report errors just because it had to wait.
+
+        The regression this guards: routing "not ready" through `_retry_strategy` made its
+        `after_retry` hook log `Attempt N failed with error: status_code: 202` on the happy path.
+        """
+        body = _pack({"result": _tagged_table()})
+        attempts = []
+
+        def flaky_result(self, client, endpoint, job_id):
+            attempts.append(job_id)
+            if len(attempts) < 3:
+                raise ApiError(status_code=202, body={"detail": "not ready"})
+            return {}, body
+
+        _stub_submit_binary(monkeypatch)
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_poll_job",
+            lambda self, c, e, j, pi, pt: {"status": "succeeded", "result": None},
+        )
+        monkeypatch.setattr(NixtlaClient, "_get_job_result_bytes", flaky_result)
+
+        with caplog.at_level(logging.ERROR):
+            res = (
+                _client().submit_execute_step_job(**_call_kwargs()).wait(poll_interval=0)
+            )
+
+        assert res["result"].num_rows == 3
+        assert len(attempts) == 3
+        assert caplog.records == []
+
+    def test_a_result_that_never_arrives_times_out(self, monkeypatch):
+        # Surfacing a bare ApiError(202) would read like a bug rather than "still processing".
+        def never_ready(self, client, endpoint, job_id):
+            raise ApiError(status_code=202, body={"detail": "not ready"})
+
+        _stub_submit_binary(monkeypatch)
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_poll_job",
+            lambda self, c, e, j, pi, pt: {"status": "succeeded", "result": None},
+        )
+        monkeypatch.setattr(NixtlaClient, "_get_job_result_bytes", never_ready)
+
+        job = _client().submit_execute_step_job(**_call_kwargs())
+        with pytest.raises(AsyncJobTimeoutError) as exc:
+            job.wait(poll_interval=0, poll_timeout=0.05)
+        assert exc.value.job_id == "es-1"
+
+    def test_a_non_retriable_result_error_surfaces_immediately(self, monkeypatch):
+        attempts = []
+
+        def boom(self, client, endpoint, job_id):
+            attempts.append(job_id)
+            raise ApiError(status_code=500, body={"detail": "boom"})
+
+        _stub_submit_binary(monkeypatch)
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_poll_job",
+            lambda self, c, e, j, pi, pt: {"status": "succeeded", "result": None},
+        )
+        monkeypatch.setattr(NixtlaClient, "_get_job_result_bytes", boom)
+
+        job = _client().submit_execute_step_job(**_call_kwargs())
+        with pytest.raises(ApiError) as exc:
+            job.wait(poll_interval=0)
+        assert exc.value.status_code == 500
+        assert len(attempts) == 1
+
+    def test_a_transient_error_while_fetching_is_still_retried(self, monkeypatch):
+        # The same loop covers genuine network failures, so dropping 202 from retriable_codes
+        # must not stop those from being retried.
+        body = _pack({"result": _tagged_table()})
+        attempts = []
+
+        def flaky(self, client, endpoint, job_id):
+            attempts.append(job_id)
+            if len(attempts) == 1:
+                raise httpx.ReadTimeout("timed out")
+            return {}, body
+
+        _stub_submit_binary(monkeypatch)
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_poll_job",
+            lambda self, c, e, j, pi, pt: {"status": "succeeded", "result": None},
+        )
+        monkeypatch.setattr(NixtlaClient, "_get_job_result_bytes", flaky)
+
+        res = _client().submit_execute_step_job(**_call_kwargs()).wait(poll_interval=0)
         assert len(attempts) == 2
         assert res["result"].num_rows == 3
 

--- a/nixtla_tests/nixtla_client/test_execute_step_job.py
+++ b/nixtla_tests/nixtla_client/test_execute_step_job.py
@@ -11,10 +11,12 @@ Fully mocked, like `test_async_jobs.py` — no network.
 """
 
 import json
+import logging
 import zipfile
 from io import BytesIO
 from unittest.mock import MagicMock
 
+import httpx
 import orjson
 import pandas as pd
 import pytest
@@ -27,18 +29,36 @@ from nixtla.steps import (  # noqa: E402
     HEADER_BUDGET,
     METADATA_HEADER,
     StepResult,
+    _collect_refs,
+    _pack,
+    _unpack,
     build_request,
     build_result,
-    collect_refs,
-    pack,
     ref,
     to_arrow,
-    unpack,
 )
 
 
 def _client(**kwargs):
     return NixtlaClient(api_key="dummy", **kwargs)
+
+
+def _mock_json_response(status_code, body):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = orjson.dumps(body)
+    return resp
+
+
+def _stub_submit_binary(monkeypatch, job_id="es-1", capture=None):
+    """Make `_submit_binary_job` succeed without HTTP, optionally recording its args."""
+
+    def fake_submit(self, client, endpoint, metadata, body):
+        if capture is not None:
+            capture.append({"endpoint": endpoint, "metadata": metadata, "body": body})
+        return job_id
+
+    monkeypatch.setattr(NixtlaClient, "_submit_binary_job", fake_submit)
 
 
 def _small_df(n=5):
@@ -76,7 +96,7 @@ def _call_kwargs(**overrides):
 class TestCodec:
     def test_pack_unpack_round_trip(self):
         tables = {"a": pa.table({"x": [1, 2]}), "b": pa.table({"y": ["p", "q"]})}
-        restored = unpack(pack(tables))
+        restored = _unpack(_pack(tables))
         assert set(restored) == {"a", "b"}
         assert restored["a"].column("x").to_pylist() == [1, 2]
 
@@ -84,21 +104,21 @@ class TestCodec:
         # The whole reason pyarrow is required: a pandas round-trip would drop this, and a
         # chained step would then misread the previous step's output.
         table = _tagged_table()
-        restored = unpack(pack({"t": table}))["t"]
+        restored = _unpack(_pack({"t": table}))["t"]
         assert restored.schema.metadata[b"tsmp_resource_meta"] == (
             b'{"resource": "arrowtsi", "freq": "D"}'
         )
 
     def test_members_are_named_for_their_key(self):
-        with zipfile.ZipFile(BytesIO(pack({"sales": pa.table({"x": [1]})}))) as zf:
+        with zipfile.ZipFile(BytesIO(_pack({"sales": pa.table({"x": [1]})}))) as zf:
             assert zf.namelist() == ["sales.parquet"]
 
     def test_layout_is_deterministic(self):
         tables = {"b": pa.table({"x": [1]}), "a": pa.table({"y": [2]})}
-        assert pack(tables) == pack({"a": tables["a"], "b": tables["b"]})
+        assert _pack(tables) == _pack({"a": tables["a"], "b": tables["b"]})
 
     def test_empty_data_map(self):
-        assert unpack(pack({})) == {}
+        assert _unpack(_pack({})) == {}
 
     def test_to_arrow_passes_a_table_through_untouched(self):
         table = _tagged_table()
@@ -121,19 +141,39 @@ class TestCodec:
             "extras": [ref("b"), {"nested": ref("c")}],
             "h": 7,
         }
-        assert collect_refs(params) == {"a", "b", "c"}
+        assert _collect_refs(params) == {"a", "b", "c"}
 
     def test_collect_refs_rejects_non_string(self):
         with pytest.raises(ValueError, match="must be a string"):
-            collect_refs({"data_ref": {"nested": "evil"}})
+            _collect_refs({"data_ref": {"nested": "evil"}})
 
     def test_build_result_reads_header_case_insensitively(self):
         # HTTP header names are not case-sensitive and proxies rewrite their case freely.
+        # `httpx.Headers` is what the client hands over, and it handles the folding.
         res = build_result(
-            {"Nixtla-Metadata": '{"func_name": "forecast"}'},
-            pack({"r": _tagged_table()}),
+            httpx.Headers({"Nixtla-Metadata": '{"func_name": "forecast"}'}),
+            _pack({"r": _tagged_table()}),
         )
         assert res.metadata["func_name"] == "forecast"
+
+    def test_build_result_without_a_metadata_header(self):
+        res = build_result(httpx.Headers({}), _pack({"r": _tagged_table()}))
+        assert res.metadata == {}
+        assert res["r"].num_rows == 3
+
+    def test_unpack_warns_about_a_member_that_is_not_a_table(self, caplog):
+        packed = _pack({"result": pa.table({"x": [1]})})
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            with zipfile.ZipFile(BytesIO(packed)) as src:
+                zf.writestr("result.parquet", src.read("result.parquet"))
+            zf.writestr("manifest.json", b"{}")
+
+        with caplog.at_level(logging.WARNING, logger="nixtla.steps"):
+            tables = _unpack(buf.getvalue())
+
+        assert set(tables) == {"result"}
+        assert "manifest.json" in caplog.text
 
     def test_step_result_accessors(self):
         res = StepResult(
@@ -167,10 +207,14 @@ class TestValidation:
                 **_call_kwargs(params={"data": ref("absent")})
             )
 
-    def test_rejects_an_unreferenced_table(self):
-        with pytest.raises(ValueError, match="no param references"):
+    def test_rejects_a_ref_alongside_a_nested_one(self):
+        # A param can hold both a data_ref and nested params referencing further tables;
+        # missing the sibling would reject this valid call as "unsupplied".
+        with pytest.raises(ValueError, match=r"\['deep'\]"):
             _client().submit_execute_step_job(
-                **_call_kwargs(data={"panel": _small_df(), "spare": _small_df()})
+                **_call_kwargs(
+                    params={"data": {**ref("panel"), "opts": ref("deep")}},
+                )
             )
 
     @pytest.mark.parametrize("key", ["../evil", "/abs", "nested/path", "", " lead"])
@@ -190,11 +234,7 @@ class TestValidation:
             )
 
     def test_accepts_a_call_with_no_data(self, monkeypatch):
-        monkeypatch.setattr(
-            NixtlaClient,
-            "_submit_binary_job",
-            lambda self, client, endpoint, metadata, body: "es-1",
-        )
+        _stub_submit_binary(monkeypatch)
         job = _client().submit_execute_step_job(
             func_name="select_by_sql", params={"query": "SELECT 1"}
         )
@@ -256,10 +296,29 @@ class TestSubmit:
         assert "model" not in decoded
         assert "job_options" not in decoded
 
-    def test_job_timeout_seconds_goes_into_the_header_not_the_body(self):
-        # Unlike the JSON tasks, this task's request metadata travels in a header.
-        metadata, _ = build_request(**_call_kwargs(), job_timeout_seconds=120)
-        assert json.loads(metadata)["job_options"] == {"timeout_seconds": 120}
+    def test_job_timeout_seconds_goes_into_the_header_not_the_body(self, monkeypatch):
+        # Unlike the JSON tasks, this task's request metadata travels in a header. Goes
+        # through the public method so it also covers the client forwarding the argument.
+        sent = []
+        _stub_submit_binary(monkeypatch, capture=sent)
+
+        _client().submit_execute_step_job(**_call_kwargs(), job_timeout_seconds=120)
+
+        assert json.loads(sent[0]["metadata"])["job_options"] == {
+            "timeout_seconds": 120
+        }
+        assert sent[0]["body"][:2] == b"PK"
+
+    def test_an_unreferenced_table_warns_and_is_still_sent(self, monkeypatch, caplog):
+        # Chaining passes a whole `.data` map, and a step can return more tables than the
+        # next one consumes -- warn, don't reject the call.
+        _stub_submit_binary(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger="nixtla.steps"):
+            job = _client().submit_execute_step_job(
+                **_call_kwargs(data={"panel": _small_df(), "spare": _small_df()})
+            )
+        assert job.job_id == "es-1"
+        assert "spare" in caplog.text
 
     def test_raises_api_error_on_a_bad_status(self):
         http_client = MagicMock()
@@ -269,13 +328,6 @@ class TestSubmit:
         assert exc.value.status_code == 422
 
 
-def _mock_json_response(status_code, body):
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.content = orjson.dumps(body)
-    return resp
-
-
 # ---------------------------------------------------------------------------
 # result retrieval
 # ---------------------------------------------------------------------------
@@ -283,16 +335,12 @@ def _mock_json_response(status_code, body):
 
 class TestResult:
     def test_wait_takes_the_fetch_result_path(self, monkeypatch):
-        body = pack({"result": _tagged_table()})
+        body = _pack({"result": _tagged_table()})
         headers = {
             METADATA_HEADER: '{"func_name": "make_forecast_input", "profile": {"num_rows": 3}}'
         }
 
-        monkeypatch.setattr(
-            NixtlaClient,
-            "_submit_binary_job",
-            lambda self, client, endpoint, metadata, body: "es-1",
-        )
+        _stub_submit_binary(monkeypatch)
         # The status response carries no result for a binary task; it must not be parsed.
         monkeypatch.setattr(
             NixtlaClient,
@@ -302,7 +350,7 @@ class TestResult:
         monkeypatch.setattr(
             NixtlaClient,
             "_get_job_result_bytes",
-            lambda self, c, e, j: (headers, body),
+            lambda self, client, endpoint, job_id: (headers, body),
         )
 
         job = _client().submit_execute_step_job(**_call_kwargs())
@@ -315,19 +363,17 @@ class TestResult:
         assert job.result is result
 
     def test_result_tables_can_be_chained_back_in(self, monkeypatch):
-        body = pack({"result": _tagged_table()})
-        monkeypatch.setattr(
-            NixtlaClient,
-            "_submit_binary_job",
-            lambda self, client, endpoint, metadata, body: "es-1",
-        )
+        body = _pack({"result": _tagged_table()})
+        _stub_submit_binary(monkeypatch)
         monkeypatch.setattr(
             NixtlaClient,
             "_poll_job",
             lambda self, c, e, j, pi, pt: {"status": "succeeded"},
         )
         monkeypatch.setattr(
-            NixtlaClient, "_get_job_result_bytes", lambda self, c, e, j: ({}, body)
+            NixtlaClient,
+            "_get_job_result_bytes",
+            lambda self, client, endpoint, job_id: ({}, body),
         )
 
         res = _client().submit_execute_step_job(**_call_kwargs()).wait(poll_interval=0)
@@ -336,7 +382,7 @@ class TestResult:
         _, chained_body = build_request(
             "forecast", {"resource": ref("result")}, res.data
         )
-        assert unpack(chained_body)["result"].schema.metadata[
+        assert _unpack(chained_body)["result"].schema.metadata[
             b"tsmp_resource_meta"
         ] == (b'{"resource": "arrowtsi", "freq": "D"}')
 
@@ -348,14 +394,43 @@ class TestResult:
         _client()._get_job_result_bytes(http_client, "v2/execute_step", "es-1")
         http_client.get.assert_called_once_with("v2/execute_step/jobs/es-1/result")
 
-    def test_conflict_while_not_ready_surfaces_as_api_error(self):
+    def test_a_bad_status_from_the_result_endpoint_raises(self):
         http_client = MagicMock()
-        resp = MagicMock(status_code=409)
-        resp.json.return_value = {"detail": "not succeeded"}
+        resp = MagicMock(status_code=422)
+        resp.json.return_value = {"detail": "nope"}
         http_client.get.return_value = resp
         with pytest.raises(ApiError) as exc:
             _client()._get_job_result_bytes(http_client, "v2/execute_step", "es-1")
-        assert exc.value.status_code == 409
+        assert exc.value.status_code == 422
+
+    def test_conflict_while_not_ready_is_retried(self, monkeypatch):
+        # The job says succeeded but the zip has not materialized yet: 409 is retriable, and
+        # giving up here would discard work the server has already done and billed.
+        body = _pack({"result": _tagged_table()})
+        attempts = []
+
+        def flaky_result(self, client, endpoint, job_id):
+            attempts.append(job_id)
+            if len(attempts) == 1:
+                raise ApiError(status_code=409, body={"detail": "not succeeded"})
+            return {}, body
+
+        _stub_submit_binary(monkeypatch)
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_poll_job",
+            lambda self, c, e, j, pi, pt: {"status": "succeeded", "result": None},
+        )
+        monkeypatch.setattr(NixtlaClient, "_get_job_result_bytes", flaky_result)
+
+        res = (
+            _client(retry_interval=0)
+            .submit_execute_step_job(**_call_kwargs())
+            .wait(poll_interval=0)
+        )
+
+        assert len(attempts) == 2
+        assert res["result"].num_rows == 3
 
 
 # ---------------------------------------------------------------------------
@@ -366,11 +441,7 @@ class TestResult:
 class TestJobSurface:
     def test_cancel_uses_the_task_agnostic_endpoint(self, monkeypatch):
         calls = []
-        monkeypatch.setattr(
-            NixtlaClient,
-            "_submit_binary_job",
-            lambda self, client, endpoint, metadata, body: "es-1",
-        )
+        _stub_submit_binary(monkeypatch)
         monkeypatch.setattr(
             NixtlaClient,
             "_cancel_job",

--- a/nixtla_tests/nixtla_client/test_execute_step_job.py
+++ b/nixtla_tests/nixtla_client/test_execute_step_job.py
@@ -1,0 +1,404 @@
+"""Tests for `submit_execute_step_job` and the `nixtla.steps` codec.
+
+These live apart from `test_async_jobs.py` rather than joining its `SUBMIT_JOB_CASES` /
+`WAIT_JOB_CASES` tables: those tables monkeypatch `NixtlaClient._submit_job`, and execute_step goes
+through `_submit_binary_job` instead because its request is a zip body plus a header rather than a
+JSON payload. Folding it in would mean branching inside the shared tests. The three shared
+behaviours (returns a Job, wait returns the result, job_timeout_seconds is threaded through) are
+reproduced here for the binary path.
+
+Fully mocked, like `test_async_jobs.py` — no network.
+"""
+
+import json
+import zipfile
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import orjson
+import pandas as pd
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+
+from nixtla.nixtla_client import ApiError, Job, NixtlaClient  # noqa: E402
+from nixtla.steps import (  # noqa: E402
+    CONTENT_TYPE,
+    HEADER_BUDGET,
+    METADATA_HEADER,
+    StepResult,
+    build_request,
+    build_result,
+    collect_refs,
+    pack,
+    ref,
+    to_arrow,
+    unpack,
+)
+
+
+def _client(**kwargs):
+    return NixtlaClient(api_key="dummy", **kwargs)
+
+
+def _small_df(n=5):
+    return pd.DataFrame(
+        {
+            "unique_id": "id_0",
+            "ds": pd.date_range("2020-01-01", periods=n, freq="D"),
+            "y": range(n),
+        }
+    )
+
+
+def _tagged_table():
+    """A table carrying the resource identity the server stamps into schema metadata."""
+    return pa.table({"a": [1, 2, 3]}).replace_schema_metadata(
+        {b"tsmp_resource_meta": b'{"resource": "arrowtsi", "freq": "D"}'}
+    )
+
+
+def _call_kwargs(**overrides):
+    kwargs = {
+        "func_name": "make_forecast_input",
+        "params": {"data": ref("panel"), "freq": "D"},
+        "data": {"panel": _small_df()},
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# codec
+# ---------------------------------------------------------------------------
+
+
+class TestCodec:
+    def test_pack_unpack_round_trip(self):
+        tables = {"a": pa.table({"x": [1, 2]}), "b": pa.table({"y": ["p", "q"]})}
+        restored = unpack(pack(tables))
+        assert set(restored) == {"a", "b"}
+        assert restored["a"].column("x").to_pylist() == [1, 2]
+
+    def test_schema_metadata_survives(self):
+        # The whole reason pyarrow is required: a pandas round-trip would drop this, and a
+        # chained step would then misread the previous step's output.
+        table = _tagged_table()
+        restored = unpack(pack({"t": table}))["t"]
+        assert restored.schema.metadata[b"tsmp_resource_meta"] == (
+            b'{"resource": "arrowtsi", "freq": "D"}'
+        )
+
+    def test_members_are_named_for_their_key(self):
+        with zipfile.ZipFile(BytesIO(pack({"sales": pa.table({"x": [1]})}))) as zf:
+            assert zf.namelist() == ["sales.parquet"]
+
+    def test_layout_is_deterministic(self):
+        tables = {"b": pa.table({"x": [1]}), "a": pa.table({"y": [2]})}
+        assert pack(tables) == pack({"a": tables["a"], "b": tables["b"]})
+
+    def test_empty_data_map(self):
+        assert unpack(pack({})) == {}
+
+    def test_to_arrow_passes_a_table_through_untouched(self):
+        table = _tagged_table()
+        assert to_arrow(table) is table
+
+    def test_to_arrow_converts_pandas(self):
+        assert to_arrow(_small_df()).num_rows == 5
+
+    def test_to_arrow_converts_polars(self):
+        pl = pytest.importorskip("polars")
+        assert to_arrow(pl.DataFrame({"x": [1, 2, 3]})).num_rows == 3
+
+    def test_to_arrow_rejects_unsupported_input(self):
+        with pytest.raises(TypeError, match="pyarrow Tables or eager pandas/polars"):
+            to_arrow([1, 2, 3])
+
+    def test_collect_refs_finds_every_depth(self):
+        params = {
+            "resource": ref("a"),
+            "extras": [ref("b"), {"nested": ref("c")}],
+            "h": 7,
+        }
+        assert collect_refs(params) == {"a", "b", "c"}
+
+    def test_collect_refs_rejects_non_string(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            collect_refs({"data_ref": {"nested": "evil"}})
+
+    def test_build_result_reads_header_case_insensitively(self):
+        # HTTP header names are not case-sensitive and proxies rewrite their case freely.
+        res = build_result(
+            {"Nixtla-Metadata": '{"func_name": "forecast"}'},
+            pack({"r": _tagged_table()}),
+        )
+        assert res.metadata["func_name"] == "forecast"
+
+    def test_step_result_accessors(self):
+        res = StepResult(
+            data={"result": _tagged_table()}, metadata={"func_name": "forecast"}
+        )
+        assert "result" in res
+        assert list(res.keys()) == ["result"]
+        assert res["result"].num_rows == 3
+        assert isinstance(res.to_pandas()["result"], pd.DataFrame)
+        assert "forecast" in repr(res)
+
+
+# ---------------------------------------------------------------------------
+# client-side validation, before anything is uploaded
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    @pytest.fixture(autouse=True)
+    def no_http(self, monkeypatch):
+        """Any HTTP attempt is a test failure: these must all fail locally."""
+
+        def boom(*args, **kwargs):
+            raise AssertionError("validation should fail before any HTTP call")
+
+        monkeypatch.setattr(NixtlaClient, "_submit_binary_job", boom)
+
+    def test_rejects_a_ref_with_no_table(self):
+        with pytest.raises(ValueError, match="not supplied"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(params={"data": ref("absent")})
+            )
+
+    def test_rejects_an_unreferenced_table(self):
+        with pytest.raises(ValueError, match="no param references"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(data={"panel": _small_df(), "spare": _small_df()})
+            )
+
+    @pytest.mark.parametrize("key", ["../evil", "/abs", "nested/path", "", " lead"])
+    def test_rejects_unsafe_data_keys(self, key):
+        with pytest.raises(ValueError, match="data key"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(params={"data": ref(key)}, data={key: _small_df()})
+            )
+
+    def test_rejects_metadata_over_the_header_budget(self):
+        # The server answers 431 and deliberately does not spill metadata into the body.
+        with pytest.raises(ValueError, match="over the .* budget"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(
+                    params={"data": ref("panel"), "sql": "x" * (HEADER_BUDGET + 1)}
+                )
+            )
+
+    def test_accepts_a_call_with_no_data(self, monkeypatch):
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_submit_binary_job",
+            lambda self, client, endpoint, metadata, body: "es-1",
+        )
+        job = _client().submit_execute_step_job(
+            func_name="select_by_sql", params={"query": "SELECT 1"}
+        )
+        assert job.job_id == "es-1"
+
+
+# ---------------------------------------------------------------------------
+# submit
+# ---------------------------------------------------------------------------
+
+
+class TestSubmit:
+    def test_returns_a_job_for_the_execute_step_endpoint(self, monkeypatch):
+        calls = []
+
+        def fake_submit(self, client, endpoint, metadata, body):
+            calls.append(endpoint)
+            return "es-abc123"
+
+        monkeypatch.setattr(NixtlaClient, "_submit_binary_job", fake_submit)
+        monkeypatch.setattr(
+            NixtlaClient, "_get_job_data", lambda self, c, e, j: {"status": "pending"}
+        )
+
+        job = _client().submit_execute_step_job(**_call_kwargs())
+
+        assert isinstance(job, Job)
+        assert job.job_id == "es-abc123"
+        assert job.status == "pending"
+        assert calls == ["v2/execute_step"]
+
+    def test_sends_zip_body_and_metadata_header_uncompressed(self):
+        http_client = MagicMock()
+        http_client.post.return_value = _mock_json_response(202, {"job_id": "es-1"})
+
+        metadata, body = build_request(**_call_kwargs())
+        job_id = _client()._submit_binary_job(
+            http_client, "v2/execute_step", metadata, body
+        )
+
+        assert job_id == "es-1"
+        _, kwargs = http_client.post.call_args
+        assert kwargs["url"] == "v2/execute_step/async"
+        assert kwargs["headers"]["content-type"] == CONTENT_TYPE
+        # Overrides the client-level application/json default.
+        assert kwargs["headers"][METADATA_HEADER] == metadata
+        # The zip is already deflated, so it must not be zstd-compressed on top.
+        assert "content-encoding" not in kwargs["headers"]
+        assert kwargs["content"] is body
+        assert kwargs["content"][:2] == b"PK"
+
+    def test_metadata_carries_only_func_name_and_params(self):
+        # No `model`: the step names its models in `params`, and the server rejects an unknown
+        # metadata key outright.
+        metadata, _ = build_request(**_call_kwargs())
+        decoded = json.loads(metadata)
+        assert decoded["func_name"] == "make_forecast_input"
+        assert decoded["params"]["data"] == {"data_ref": "panel"}
+        assert "model" not in decoded
+        assert "job_options" not in decoded
+
+    def test_job_timeout_seconds_goes_into_the_header_not_the_body(self):
+        # Unlike the JSON tasks, this task's request metadata travels in a header.
+        metadata, _ = build_request(**_call_kwargs(), job_timeout_seconds=120)
+        assert json.loads(metadata)["job_options"] == {"timeout_seconds": 120}
+
+    def test_raises_api_error_on_a_bad_status(self):
+        http_client = MagicMock()
+        http_client.post.return_value = _mock_json_response(422, {"detail": "nope"})
+        with pytest.raises(ApiError) as exc:
+            _client()._submit_binary_job(http_client, "v2/execute_step", "{}", b"PK")
+        assert exc.value.status_code == 422
+
+
+def _mock_json_response(status_code, body):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = orjson.dumps(body)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# result retrieval
+# ---------------------------------------------------------------------------
+
+
+class TestResult:
+    def test_wait_takes_the_fetch_result_path(self, monkeypatch):
+        body = pack({"result": _tagged_table()})
+        headers = {
+            METADATA_HEADER: '{"func_name": "make_forecast_input", "profile": {"num_rows": 3}}'
+        }
+
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_submit_binary_job",
+            lambda self, client, endpoint, metadata, body: "es-1",
+        )
+        # The status response carries no result for a binary task; it must not be parsed.
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_poll_job",
+            lambda self, c, e, j, pi, pt: {"status": "succeeded", "result": None},
+        )
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_get_job_result_bytes",
+            lambda self, c, e, j: (headers, body),
+        )
+
+        job = _client().submit_execute_step_job(**_call_kwargs())
+        result = job.wait(poll_interval=0, poll_timeout=1)
+
+        assert isinstance(result, StepResult)
+        assert result["result"].num_rows == 3
+        assert result.metadata["profile"]["num_rows"] == 3
+        assert job.status == "succeeded"
+        assert job.result is result
+
+    def test_result_tables_can_be_chained_back_in(self, monkeypatch):
+        body = pack({"result": _tagged_table()})
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_submit_binary_job",
+            lambda self, client, endpoint, metadata, body: "es-1",
+        )
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_poll_job",
+            lambda self, c, e, j, pi, pt: {"status": "succeeded"},
+        )
+        monkeypatch.setattr(
+            NixtlaClient, "_get_job_result_bytes", lambda self, c, e, j: ({}, body)
+        )
+
+        res = _client().submit_execute_step_job(**_call_kwargs()).wait(poll_interval=0)
+
+        # Feeding `.data` straight back must preserve the resource tag end to end.
+        _, chained_body = build_request(
+            "forecast", {"resource": ref("result")}, res.data
+        )
+        assert unpack(chained_body)["result"].schema.metadata[
+            b"tsmp_resource_meta"
+        ] == (b'{"resource": "arrowtsi", "freq": "D"}')
+
+    def test_result_endpoint_hits_the_right_url(self):
+        http_client = MagicMock()
+        http_client.get.return_value = MagicMock(
+            status_code=200, headers={}, content=b"PK"
+        )
+        _client()._get_job_result_bytes(http_client, "v2/execute_step", "es-1")
+        http_client.get.assert_called_once_with("v2/execute_step/jobs/es-1/result")
+
+    def test_conflict_while_not_ready_surfaces_as_api_error(self):
+        http_client = MagicMock()
+        resp = MagicMock(status_code=409)
+        resp.json.return_value = {"detail": "not succeeded"}
+        http_client.get.return_value = resp
+        with pytest.raises(ApiError) as exc:
+            _client()._get_job_result_bytes(http_client, "v2/execute_step", "es-1")
+        assert exc.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# the shared Job surface still works for this job type
+# ---------------------------------------------------------------------------
+
+
+class TestJobSurface:
+    def test_cancel_uses_the_task_agnostic_endpoint(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_submit_binary_job",
+            lambda self, client, endpoint, metadata, body: "es-1",
+        )
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_cancel_job",
+            lambda self, client, job_id: calls.append(job_id),
+        )
+
+        job = _client().submit_execute_step_job(**_call_kwargs())
+        job.cancel()
+
+        assert calls == ["es-1"]
+        assert job.status == "cancelled"
+
+    def test_json_jobs_still_take_the_parse_result_path(self, monkeypatch):
+        """Regression guard on the `fetch_result` hook added to `Job`."""
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_submit_job",
+            lambda self, c, e, p, multithreaded_compress=True: "ft-1",
+        )
+        monkeypatch.setattr(
+            NixtlaClient,
+            "_poll_job",
+            lambda self, c, e, j, pi, pt: {
+                "status": "succeeded",
+                "result": {"finetuned_model_id": "model-abc"},
+            },
+        )
+
+        job = _client().submit_finetune_job(df=_small_df(n=20), freq="D")
+
+        assert job.wait(poll_interval=0, poll_timeout=1) == "model-abc"

--- a/nixtla_tests/nixtla_client/test_execute_step_job.py
+++ b/nixtla_tests/nixtla_client/test_execute_step_job.py
@@ -118,6 +118,13 @@ class TestCodec:
         tables = {"b": pa.table({"x": [1]}), "a": pa.table({"y": [2]})}
         assert _pack(tables) == _pack({"a": tables["a"], "b": tables["b"]})
 
+    def test_pack_does_not_stamp_the_clock(self):
+        # Without a fixed epoch `test_layout_is_deterministic` only passes when both calls land
+        # in the same 2-second timestamp bucket, so it would flake at a boundary.
+        tables = {"a": pa.table({"x": [1]})}
+        with zipfile.ZipFile(BytesIO(_pack(tables))) as zf:
+            assert zf.getinfo("a.parquet").date_time == (1980, 1, 1, 0, 0, 0)
+
     def test_empty_data_map(self):
         assert _unpack(_pack({})) == {}
 
@@ -143,13 +150,58 @@ class TestCodec:
         assert list(filtered.index) != list(range(len(filtered)))
         assert to_arrow(filtered).column_names == ["unique_id", "ds", "y"]
 
-    def test_to_arrow_folds_a_named_pandas_index_into_a_column(self):
-        # Dropping it would silently cost the caller the id column they meant to send.
-        indexed = _small_df().set_index("unique_id")
-        assert set(to_arrow(indexed).column_names) == {"unique_id", "ds", "y"}
-
     def test_to_arrow_leaves_a_default_range_index_alone(self):
         assert to_arrow(_small_df()).column_names == ["unique_id", "ds", "y"]
+
+    def test_to_arrow_drops_a_fully_unnamed_multiindex(self):
+        df = _small_df()
+        df.index = pd.MultiIndex.from_arrays(
+            [range(len(df)), range(len(df))], names=[None, None]
+        )
+        assert to_arrow(df).column_names == ["unique_id", "ds", "y"]
+
+    @pytest.mark.parametrize(
+        "make_index",
+        [
+            pytest.param(lambda df: df.set_index("unique_id"), id="named-single"),
+            pytest.param(
+                lambda df: df.set_index(["unique_id", "ds"]), id="named-multi"
+            ),
+        ],
+    )
+    def test_to_arrow_rejects_a_named_index(self, make_index):
+        # The name says the values matter but not whether they should be a column.
+        with pytest.raises(ValueError, match="named index level"):
+            to_arrow(make_index(_small_df()))
+
+    def test_to_arrow_rejects_a_partially_named_multiindex(self):
+        # What `groupby(key).apply(...)` produces. Promoting it injects a junk `level_1` column.
+        df = _small_df()
+        df.index = pd.MultiIndex.from_arrays(
+            [df["unique_id"], range(len(df))], names=["uid", None]
+        )
+        with pytest.raises(ValueError, match="named index level 'uid'"):
+            to_arrow(df)
+
+    def test_to_arrow_names_the_offending_data_key(self):
+        # A call passing several tables is otherwise very hard to debug.
+        with pytest.raises(ValueError, match=r"data\['panel'\]"):
+            to_arrow(_small_df().set_index("unique_id"), "panel")
+
+    def test_to_arrow_rejects_an_index_colliding_with_a_column(self):
+        # Previously surfaced as a bare pandas "cannot insert unique_id, already exists".
+        # A list (not a range) so this is a materialized index rather than a RangeIndex.
+        df = _small_df()
+        df.index = pd.Index(list(range(len(df))), name="unique_id")
+        with pytest.raises(ValueError, match="named index level"):
+            to_arrow(df, "panel")
+
+    def test_to_arrow_allows_a_named_default_range_index(self):
+        # A RangeIndex is stored as arrow metadata whatever its name, so no column can leak and
+        # there is nothing ambiguous to reject.
+        df = _small_df()
+        df.index = pd.RangeIndex(len(df), name="row")
+        assert to_arrow(df).column_names == ["unique_id", "ds", "y"]
 
     def test_collect_refs_finds_every_depth(self):
         params = {
@@ -292,6 +344,34 @@ class TestValidation:
                 **_call_kwargs(params={"data": ref("panel"), "deep": deep})
             )
 
+    def test_deep_nesting_raises_before_the_recursive_ref_walk(self):
+        # The depth guard must run before the recursive ref walk, or the caller sees a
+        # RecursionError instead of the actionable limit message.
+        deep = inner = {}
+        for _ in range(3000):
+            inner["k"] = inner = {}
+        with pytest.raises(ValueError, match=f"deeper than {MAX_METADATA_DEPTH}"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(params={"data": ref("panel"), "deep": deep})
+            )
+
+    def test_self_referential_params_raise_rather_than_recursing_forever(self):
+        params = {"data": ref("panel")}
+        params["me"] = params
+        with pytest.raises(ValueError, match=f"deeper than {MAX_METADATA_DEPTH}"):
+            _client().submit_execute_step_job(**_call_kwargs(params=params))
+
+    def test_a_bad_ref_raises_before_any_table_is_converted(self, monkeypatch):
+        # Cheapest-first: a bad reference should cost no arrow conversion.
+        def boom(*args, **kwargs):
+            raise AssertionError("no table should be converted")
+
+        monkeypatch.setattr("nixtla.steps.to_arrow", boom)
+        with pytest.raises(ValueError, match="not supplied"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(params={"data": ref("absent")})
+            )
+
     def test_rejects_a_body_over_the_server_limit(self, monkeypatch):
         # Without this the request is accepted and only reported as a failed job later, so the
         # error would surface long after the call that caused it.
@@ -391,16 +471,35 @@ class TestSubmit:
         }
         assert sent[0]["body"][:2] == b"PK"
 
-    def test_an_unreferenced_table_warns_and_is_still_sent(self, monkeypatch, caplog):
-        # Chaining passes a whole `.data` map, and a step can return more tables than the
-        # next one consumes -- warn, don't reject the call.
-        _stub_submit_binary(monkeypatch)
+    def test_an_unreferenced_table_is_accepted_but_not_uploaded(
+        self, monkeypatch, caplog
+    ):
+        # Chaining passes a whole `.data` map and a step can return more tables than the next one
+        # consumes, so this must be accepted -- but the extra is ignored, so shipping it would
+        # spend bandwidth for nothing.
+        sent = []
+        _stub_submit_binary(monkeypatch, capture=sent)
         with caplog.at_level(logging.WARNING, logger="nixtla.steps"):
             job = _client().submit_execute_step_job(
                 **_call_kwargs(data={"panel": _small_df(), "spare": _small_df()})
             )
+
         assert job.job_id == "es-1"
-        assert "spare" in caplog.text
+        with zipfile.ZipFile(BytesIO(sent[0]["body"])) as zf:
+            assert zf.namelist() == ["panel.parquet"]
+        # The pattern is free now, so it should not nag.
+        assert caplog.text == ""
+
+    def test_an_unreferenced_table_does_not_count_against_the_body_budget(
+        self, monkeypatch
+    ):
+        # Previously a big spare table could push a chained call over MAX_BODY_BYTES on its own.
+        _stub_submit_binary(monkeypatch)
+        monkeypatch.setattr("nixtla.steps.MAX_BODY_BYTES", 4096)
+        job = _client().submit_execute_step_job(
+            **_call_kwargs(data={"panel": _small_df(), "spare": _small_df(n=50_000)})
+        )
+        assert job.job_id == "es-1"
 
     def test_raises_api_error_on_a_bad_status(self):
         http_client = MagicMock()
@@ -408,6 +507,21 @@ class TestSubmit:
         with pytest.raises(ApiError) as exc:
             _client()._submit_binary_job(http_client, "v2/execute_step", "{}", b"PK")
         assert exc.value.status_code == 422
+
+    def test_unwraps_a_data_envelope(self):
+        http_client = MagicMock()
+        http_client.post.return_value = _mock_json_response(200, {"data": {"job_id": "es-9"}})
+        job_id = _client()._submit_binary_job(
+            http_client, "v2/execute_step", "{}", b"PK"
+        )
+        assert job_id == "es-9"
+
+    def test_raises_api_error_when_the_response_has_no_job_id(self):
+        # Otherwise this surfaces as a bare KeyError rather than something callers can handle.
+        http_client = MagicMock()
+        http_client.post.return_value = _mock_json_response(200, {"unexpected": 1})
+        with pytest.raises(ApiError, match="no job_id"):
+            _client()._submit_binary_job(http_client, "v2/execute_step", "{}", b"PK")
 
 
 # ---------------------------------------------------------------------------

--- a/nixtla_tests/nixtla_client/test_execute_step_job.py
+++ b/nixtla_tests/nixtla_client/test_execute_step_job.py
@@ -26,6 +26,8 @@ from nixtla.nixtla_client import ApiError, Job, NixtlaClient, _is_retriable_erro
 from nixtla.steps import (
     CONTENT_TYPE,
     HEADER_BUDGET,
+    MAX_MEMBERS,
+    MAX_METADATA_DEPTH,
     METADATA_HEADER,
     StepResult,
     _collect_refs,
@@ -134,6 +136,21 @@ class TestCodec:
         with pytest.raises(TypeError, match="pyarrow Tables or eager pandas/polars"):
             to_arrow([1, 2, 3])
 
+    def test_to_arrow_drops_a_positional_pandas_index(self):
+        # Arrow serializes any non-default index as a column, so an ordinary filter would
+        # otherwise upload a phantom `__index_level_0__` that TSMP rebuilds the resource around.
+        filtered = _small_df()[lambda df: df["y"] > 1]
+        assert list(filtered.index) != list(range(len(filtered)))
+        assert to_arrow(filtered).column_names == ["unique_id", "ds", "y"]
+
+    def test_to_arrow_folds_a_named_pandas_index_into_a_column(self):
+        # Dropping it would silently cost the caller the id column they meant to send.
+        indexed = _small_df().set_index("unique_id")
+        assert set(to_arrow(indexed).column_names) == {"unique_id", "ds", "y"}
+
+    def test_to_arrow_leaves_a_default_range_index_alone(self):
+        assert to_arrow(_small_df()).column_names == ["unique_id", "ds", "y"]
+
     def test_collect_refs_finds_every_depth(self):
         params = {
             "resource": ref("a"),
@@ -145,6 +162,23 @@ class TestCodec:
     def test_collect_refs_rejects_non_string(self):
         with pytest.raises(ValueError, match="must be a string"):
             _collect_refs({"data_ref": {"nested": "evil"}})
+
+    def test_collect_refs_stops_at_an_envelope(self):
+        # The server replaces the whole envelope with the one table `data_ref` names, so a step's
+        # own `result` envelope -- which carries `resource`/`schema_expr` siblings -- feeds straight
+        # back in without those being mistaken for anything.
+        envelope = {
+            "data_ref": "result",
+            "resource": "arrowtsi",
+            "schema_expr": {"y": "f64"},
+        }
+        assert _collect_refs({"resource": envelope}) == {"result"}
+
+    def test_collect_refs_rejects_a_ref_nested_under_an_envelope(self):
+        # The server never reads it, so allowing it through would upload `deep` and leave the
+        # param it was meant for unset -- a quietly wrong result rather than an error.
+        with pytest.raises(ValueError, match="never reads a nested reference"):
+            _collect_refs({"data": {**ref("panel"), "opts": ref("deep")}})
 
     def test_build_result_reads_header_case_insensitively(self):
         # HTTP header names are not case-sensitive and proxies rewrite their case freely.
@@ -159,6 +193,19 @@ class TestCodec:
         res = build_result(httpx.Headers({}), _pack({"r": _tagged_table()}))
         assert res.metadata == {}
         assert res["r"].num_rows == 3
+
+    @pytest.mark.parametrize("value", ["not json at all", '["a", "list"]'])
+    def test_build_result_tolerates_an_unusable_metadata_header(self, value, caplog):
+        # A result whose tables came back intact should not be discarded because the metadata
+        # describing it is unusable -- the caller can still read everything from `.data`.
+        with caplog.at_level(logging.WARNING, logger="nixtla.steps"):
+            res = build_result(
+                httpx.Headers({METADATA_HEADER: value}), _pack({"r": _tagged_table()})
+            )
+
+        assert res.metadata == {}
+        assert res["r"].num_rows == 3
+        assert METADATA_HEADER in caplog.text
 
     def test_unpack_warns_about_a_member_that_is_not_a_table(self, caplog):
         packed = _pack({"result": pa.table({"x": [1]})})
@@ -206,15 +253,51 @@ class TestValidation:
                 **_call_kwargs(params={"data": ref("absent")})
             )
 
-    def test_rejects_a_ref_alongside_a_nested_one(self):
-        # A param can hold both a data_ref and nested params referencing further tables;
-        # missing the sibling would reject this valid call as "unsupplied".
+    def test_rejects_a_ref_nested_under_an_envelope(self):
+        # `decode` replaces the envelope with the table `data_ref` names and never recurses into
+        # its siblings, so accepting this would upload `deep` and leave `opts` unset server-side.
         with pytest.raises(ValueError, match=r"\['deep'\]"):
             _client().submit_execute_step_job(
                 **_call_kwargs(
                     params={"data": {**ref("panel"), "opts": ref("deep")}},
+                    data={"panel": _small_df(), "deep": _small_df()},
                 )
             )
+
+    @pytest.mark.parametrize("func_name", ["", "f" * 129])
+    def test_rejects_a_func_name_outside_the_servers_bounds(self, func_name):
+        with pytest.raises(ValueError, match="func_name must be a string"):
+            _client().submit_execute_step_job(**_call_kwargs(func_name=func_name))
+
+    @pytest.mark.parametrize("timeout", [0, -1])
+    def test_rejects_a_non_positive_job_timeout(self, timeout):
+        with pytest.raises(ValueError, match="job_timeout_seconds must be positive"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(job_timeout_seconds=timeout)
+            )
+
+    def test_rejects_more_tables_than_the_server_accepts(self):
+        data = {f"t{i}": _small_df(1) for i in range(MAX_MEMBERS + 1)}
+        with pytest.raises(ValueError, match=f"over the {MAX_MEMBERS}"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(params={"data": ref("t0")}, data=data)
+            )
+
+    def test_rejects_metadata_nested_deeper_than_the_server_parses(self):
+        deep = inner = {}
+        for _ in range(MAX_METADATA_DEPTH + 2):
+            inner["k"] = inner = {}
+        with pytest.raises(ValueError, match=f"deeper than {MAX_METADATA_DEPTH}"):
+            _client().submit_execute_step_job(
+                **_call_kwargs(params={"data": ref("panel"), "deep": deep})
+            )
+
+    def test_rejects_a_body_over_the_server_limit(self, monkeypatch):
+        # Without this the request is accepted and only reported as a failed job later, so the
+        # error would surface long after the call that caused it.
+        monkeypatch.setattr("nixtla.steps.MAX_BODY_BYTES", 128)
+        with pytest.raises(ValueError, match="over the 128-byte limit"):
+            _client().submit_execute_step_job(**_call_kwargs())
 
     @pytest.mark.parametrize("key", ["../evil", "/abs", "nested/path", "", " lead"])
     def test_rejects_unsafe_data_keys(self, key):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Needed by submit_execute_step_job: the wire format is parquet, and the resource identity
+# of a table lives in arrow schema metadata that a pandas round-trip would drop.
+steps = ["pyarrow>=14.0.0"]
 dev = [
     "datasetsforecast",
     "fire",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "narwhals>=2.11.0",
     "orjson",
     "pandas<3.0.0",
+    "pyarrow>=14.0.0",
     "pydantic>=1.10",
     "tenacity",
     "tqdm",
@@ -36,9 +37,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Needed by submit_execute_step_job: the wire format is parquet, and the resource identity
-# of a table lives in arrow schema metadata that a pandas round-trip would drop.
-steps = ["pyarrow>=14.0.0,<24.0.0"]
 dev = [
     "datasetsforecast",
     "fire",
@@ -61,7 +59,6 @@ dev = [
     "pytest",
     "pytest-cov",
     "pytest-rerunfailures",
-    "pyarrow<24.0.0",
     "mlforecast",
     "lightgbm",
     "utilsforecast[plotting]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "narwhals>=2.11.0",
     "orjson",
     "pandas<3.0.0",
-    "pyarrow>=14.0.0",
+    "pyarrow>=14.0.0,<24.0.0",
     "pydantic>=1.10",
     "tenacity",
     "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 [project.optional-dependencies]
 # Needed by submit_execute_step_job: the wire format is parquet, and the resource identity
 # of a table lives in arrow schema metadata that a pandas round-trip would drop.
-steps = ["pyarrow>=14.0.0"]
+steps = ["pyarrow>=14.0.0,<24.0.0"]
 dev = [
     "datasetsforecast",
     "fire",

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pyarrow", specifier = ">=14.0.0" },
+    { name = "pyarrow", specifier = ">=14.0.0,<24.0.0" },
     { name = "pydantic", specifier = ">=1.10" },
     { name = "pyreadr", marker = "extra == 'dev'", specifier = "<0.5.3" },
     { name = "pyspark", marker = "extra == 'dev'", specifier = "<=4.0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -2998,6 +2998,9 @@ snowflake = [
     { name = "rich" },
     { name = "snowflake-snowpark-python" },
 ]
+steps = [
+    { name = "pyarrow" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -3029,6 +3032,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyarrow", marker = "extra == 'dev'", specifier = "<24.0.0" },
+    { name = "pyarrow", marker = "extra == 'steps'", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=1.10" },
     { name = "pyreadr", marker = "extra == 'dev'", specifier = "<0.5.3" },
     { name = "pyspark", marker = "extra == 'dev'", specifier = "<=4.0.1" },
@@ -3050,7 +3054,7 @@ requires-dist = [
     { name = "utilsforecast", extras = ["plotting"], marker = "extra == 'dev'" },
     { name = "utilsforecast", extras = ["plotting"], marker = "extra == 'plotting'" },
 ]
-provides-extras = ["dev", "distributed", "plotting", "date-extras", "snowflake"]
+provides-extras = ["steps", "dev", "distributed", "plotting", "date-extras", "snowflake"]
 
 [[package]]
 name = "nodeenv"

--- a/uv.lock
+++ b/uv.lock
@@ -3032,7 +3032,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyarrow", marker = "extra == 'dev'", specifier = "<24.0.0" },
-    { name = "pyarrow", marker = "extra == 'steps'", specifier = ">=14.0.0" },
+    { name = "pyarrow", marker = "extra == 'steps'", specifier = ">=14.0.0,<24.0.0" },
     { name = "pydantic", specifier = ">=1.10" },
     { name = "pyreadr", marker = "extra == 'dev'", specifier = "<0.5.3" },
     { name = "pyspark", marker = "extra == 'dev'", specifier = "<=4.0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -2940,6 +2940,7 @@ dependencies = [
     { name = "narwhals" },
     { name = "orjson" },
     { name = "pandas" },
+    { name = "pyarrow" },
     { name = "pydantic", version = "2.12.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "tenacity" },
@@ -2970,7 +2971,6 @@ dev = [
     { name = "plotly", version = "6.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "polars" },
     { name = "pre-commit" },
-    { name = "pyarrow" },
     { name = "pyreadr" },
     { name = "pyspark" },
     { name = "pytest" },
@@ -2997,9 +2997,6 @@ snowflake = [
     { name = "fire" },
     { name = "rich" },
     { name = "snowflake-snowpark-python" },
-]
-steps = [
-    { name = "pyarrow" },
 ]
 
 [package.metadata]
@@ -3031,8 +3028,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pyarrow", marker = "extra == 'dev'", specifier = "<24.0.0" },
-    { name = "pyarrow", marker = "extra == 'steps'", specifier = ">=14.0.0,<24.0.0" },
+    { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=1.10" },
     { name = "pyreadr", marker = "extra == 'dev'", specifier = "<0.5.3" },
     { name = "pyspark", marker = "extra == 'dev'", specifier = "<=4.0.1" },
@@ -3054,7 +3050,7 @@ requires-dist = [
     { name = "utilsforecast", extras = ["plotting"], marker = "extra == 'dev'" },
     { name = "utilsforecast", extras = ["plotting"], marker = "extra == 'plotting'" },
 ]
-provides-extras = ["steps", "dev", "distributed", "plotting", "date-extras", "snowflake"]
+provides-extras = ["dev", "distributed", "plotting", "date-extras", "snowflake"]
 
 [[package]]
 name = "nodeenv"


### PR DESCRIPTION
Adds `execute_step` to `NixtlaClient`: run one TSMP top-level API call server-side as an async job.

## New

- **`NixtlaClient.submit_execute_step_job(func_name, params, data=None, job_timeout_seconds=None)`** — submits the step and returns a `Job`; `job.wait()` returns a `StepResult`.
- **`nixtla.StepResult`** — mapping of table name to `pyarrow.Table`, plus `.metadata`. Pass `.data` straight into the next step to chain calls.
- **`nixtla.ref(key)`** — builds the `{"data_ref": key}` envelope `params` uses to reference a table in `data`.
- **`nixtla/steps.py`** — the client-side codec. Validates locally (references, table count, body size, metadata size and nesting) so a malformed request fails at the call site instead of surfacing later as a failed job.

## Behaviour changes

- **`Job.wait(cancel_on_timeout=...)` now defaults to `True`.** Previously a `poll_timeout` left the job running server-side. Code that polls in short increments and calls `wait()` again to resume must now pass `cancel_on_timeout=False`.
- A binary job's result fetch polls in its own bounded loop rather than going through the failure-retry path. Waiting no longer logs at ERROR, and giving up raises `AsyncJobTimeoutError` instead of a bare `ApiError` carrying a 202.
- `forecast()` / `cross_validation()` accept `_job_timeout_seconds` when running their work as async jobs. The per-job timeout was previously reachable only through the `submit_*_job` methods.

## Notes

- `pyarrow` moves from a dev dependency to a runtime one (`>=14,<24`). This endpoint exchanges arrow tables, and a pandas round-trip drops the schema metadata that makes chaining lossless.
- A pandas index is never sent as data: an unnamed index is dropped, and a named one raises so the caller decides whether those values belong in a column.

## Testing

`nixtla_tests/nixtla_client/test_execute_step_job.py` (new) plus additions to `test_async_jobs.py`. Fully mocked, no network — 137 offline tests pass.
