### PR TITLE
fix: Snowflake finetune procedure fails to deploy on invalid default argument

### DIFF
--- a/nbs/docs/deployment/3_snowflake.ipynb
+++ b/nbs/docs/deployment/3_snowflake.ipynb
@@ -274,7 +274,7 @@
     "```\n",
     "\n",
     "**Parameters:**\n",
-    "- `finetune_steps`: Number of fine-tuning steps (default: number of unique series)\n",
+    "- `finetune_steps`: Number of fine-tuning steps (default: 10)\n",
     "- `MAX_SERIES`: Maximum number of series to use for fine-tuning\n",
     "\n",
     "The procedure returns a model identifier that can be used in subsequent forecast calls."

--- a/nixtla/scripts/snowflake_install_nixtla.py
+++ b/nixtla/scripts/snowflake_install_nixtla.py
@@ -20,6 +20,7 @@ Options:
         - https://tsmp.nixtla.io (TimeGPT-2, supports all models)
 """
 
+import inspect
 import os
 import shutil
 import subprocess
@@ -1339,9 +1340,77 @@ def create_stored_procedures(
             print("[green]Stored procedures created![/green]")
 
 
+def nixtla_finetune_handler(
+    session: "Session",
+    input_data: str,
+    params: "Optional[dict]" = None,
+    max_series: int = 1000,
+) -> str:
+    """
+    Handler for the NIXTLA_FINETUNE stored procedure.
+
+    Shipped to Snowflake as source (see ``create_finetune_sproc``), so this
+    function must stand alone in the remote module: every import lives in the
+    body, and the annotations are quoted because ``Session`` and ``Optional``
+    are not in scope there. Snowflake resolves the argument defaults from the
+    DDL and always passes all three arguments; the Python defaults exist for
+    local callers and typing only.
+
+    Args:
+        session: Snowflake session provided by the stored procedure runtime
+        input_data: Fully qualified name of the training table
+        params: Extra keyword arguments forwarded to ``NixtlaClient.finetune``
+        max_series: Maximum number of series to finetune on
+
+    Returns:
+        Identifier of the finetuned model
+    """
+    import _snowflake  # type: ignore
+    from snowflake.snowpark import functions as F
+
+    from nixtla import NixtlaClient
+
+    if params is None:
+        params = {}
+
+    token = _snowflake.get_generic_secret_string("nixtla_api_key")
+    base_url = _snowflake.get_generic_secret_string("nixtla_base_url")
+    client = NixtlaClient(api_key=token, base_url=base_url)
+
+    input_table = session.table(input_data)
+    ids = (
+        input_table.select("unique_id", F.hash("unique_id").alias("_od"))
+        .distinct()
+        .order_by("_od")
+        .limit(max_series)
+    )
+
+    train_data = (
+        input_table.join(ids, on="unique_id", how="inner", rsuffix="_")
+        .select("unique_id", "ds", "y")
+        .order_by("unique_id", "ds")
+        .to_pandas()
+    )
+
+    train_data.columns = train_data.columns.str.lower()
+
+    if "finetune_steps" not in params:
+        params["finetune_steps"] = train_data["unique_id"].nunique()
+
+    return client.finetune(train_data, **params)
+
+
 def create_finetune_sproc(session: Session, config: DeploymentConfig) -> None:
     """
     Deploy stored procedure for finetuning.
+
+    The DDL is written by hand rather than registered with Snowpark's ``@sproc``
+    decorator. Snowpark renders a Python ``int`` default as a cast
+    (``DEFAULT 1000 :: INT``), which Snowflake rejects with
+    ``000947 invalid default argument expression``; a hand-written signature
+    emits the bare literal that Snowflake accepts, the same way TEMPLATE_SP
+    does for MAX_BATCHES. It also gives the arguments real names, so
+    ``CALL ... (INPUT_DATA => ...)`` works, and needs no cloudpickle round-trip.
 
     Args:
         session: Active Snowflake session
@@ -1351,59 +1420,36 @@ def create_finetune_sproc(session: Session, config: DeploymentConfig) -> None:
     session.use_database(config.database)
     session.use_schema(config.schema)
 
-    from snowflake.snowpark.functions import sproc
-
-    security_params = config.get_security_params()
-
-    @sproc(
-        session=session,
-        name="nixtla_finetune",
-        packages=PACKAGES,  # type: ignore[arg-type]
-        imports=[f"@{config.stage}/nixtla.zip"],
-        replace=True,
-        is_permanent=True,
-        stage_location=config.stage,
-        **security_params,
+    packages = ", ".join(f"'{package}'" for package in PACKAGES)
+    secrets = ", ".join(
+        f"'{secret}' = {config.prefix}{secret}"
+        for secret in (SECRET_API_KEY, SECRET_BASE_URL)
     )
-    def nixtla_finetune(
-        session: Session,
-        input_data: str,
-        params: Optional[dict] = None,
-        max_series: int = 1000,
-    ) -> str:
-        import _snowflake  # type: ignore
-        from snowflake.snowpark import functions as F
+    # Match the runtime Snowpark uses for the UDTFs deployed in the same run.
+    runtime_version = f"{sys.version_info.major}.{sys.version_info.minor}"
 
-        from nixtla import NixtlaClient
+    header = f"""
+CREATE OR REPLACE PROCEDURE {config.prefix}NIXTLA_FINETUNE(
+    "INPUT_DATA" VARCHAR,
+    "PARAMS" OBJECT DEFAULT NULL,
+    "MAX_SERIES" NUMBER(38,0) DEFAULT 1000
+)
+RETURNS VARCHAR
+LANGUAGE PYTHON
+RUNTIME_VERSION = '{runtime_version}'
+PACKAGES = ({packages})
+IMPORTS = ('@{config.stage}/nixtla.zip')
+EXTERNAL_ACCESS_INTEGRATIONS = ({config.integration_name})
+SECRETS = ({secrets})
+HANDLER = 'nixtla_finetune_handler'
+EXECUTE AS OWNER
+AS
+$$
+"""
+    # Concatenated, not formatted: the handler source contains braces.
+    script = header + inspect.getsource(nixtla_finetune_handler) + "$$"
 
-        if params is None:
-            params = {}
-
-        token = _snowflake.get_generic_secret_string("nixtla_api_key")
-        base_url = _snowflake.get_generic_secret_string("nixtla_base_url")
-        client = NixtlaClient(api_key=token, base_url=base_url)
-
-        input_table = session.table(input_data)
-        ids = (
-            input_table.select("unique_id", F.hash("unique_id").alias("_od"))
-            .distinct()
-            .order_by("_od")
-            .limit(max_series)
-        )
-
-        train_data = (
-            input_table.join(ids, on="unique_id", how="inner", rsuffix="_")
-            .select("unique_id", "ds", "y")
-            .order_by("unique_id", "ds")
-            .to_pandas()
-        )
-
-        train_data.columns = train_data.columns.str.lower()
-
-        if "finetune_steps" not in params:
-            params["finetune_steps"] = train_data["unique_id"].nunique()
-
-        return client.finetune(train_data, **params)
+    session.sql(script).collect()
 
     print("[green]Finetune stored procedure created![/green]")
 

--- a/nixtla/scripts/snowflake_install_nixtla.py
+++ b/nixtla/scripts/snowflake_install_nixtla.py
@@ -1341,25 +1341,19 @@ def create_stored_procedures(
 
 
 def nixtla_finetune_handler(
-    session: "Session",
+    session: Session,
     input_data: str,
-    params: "Optional[dict]" = None,
-    max_series: int = 1000,
+    params: Optional[dict],
+    max_series: int,
 ) -> str:
     """
-    Handler for the NIXTLA_FINETUNE stored procedure.
-
-    Shipped to Snowflake as source (see ``create_finetune_sproc``), so this
-    function must stand alone in the remote module: every import lives in the
-    body, and the annotations are quoted because ``Session`` and ``Optional``
-    are not in scope there. Snowflake resolves the argument defaults from the
-    DDL and always passes all three arguments; the Python defaults exist for
-    local callers and typing only.
+    Finetune TimeGPT on a table and return the finetuned model identifier.
 
     Args:
         session: Snowflake session provided by the stored procedure runtime
         input_data: Fully qualified name of the training table
-        params: Extra keyword arguments forwarded to ``NixtlaClient.finetune``
+        params: Keyword arguments forwarded to ``NixtlaClient.finetune``;
+            NULL when the caller omits the argument
         max_series: Maximum number of series to finetune on
 
     Returns:
@@ -1369,9 +1363,6 @@ def nixtla_finetune_handler(
     from snowflake.snowpark import functions as F
 
     from nixtla import NixtlaClient
-
-    if params is None:
-        params = {}
 
     token = _snowflake.get_generic_secret_string("nixtla_api_key")
     base_url = _snowflake.get_generic_secret_string("nixtla_base_url")
@@ -1394,10 +1385,7 @@ def nixtla_finetune_handler(
 
     train_data.columns = train_data.columns.str.lower()
 
-    if "finetune_steps" not in params:
-        params["finetune_steps"] = train_data["unique_id"].nunique()
-
-    return client.finetune(train_data, **params)
+    return client.finetune(train_data, **(params or {}))
 
 
 def create_finetune_sproc(session: Session, config: DeploymentConfig) -> None:
@@ -1441,13 +1429,27 @@ PACKAGES = ({packages})
 IMPORTS = ('@{config.stage}/nixtla.zip')
 EXTERNAL_ACCESS_INTEGRATIONS = ({config.integration_name})
 SECRETS = ({secrets})
-HANDLER = 'nixtla_finetune_handler'
+HANDLER = '{nixtla_finetune_handler.__name__}'
 EXECUTE AS OWNER
 AS
 $$
 """
+    source = inspect.getsource(nixtla_finetune_handler)
+
+    # Snowflake execs the body in a bare module, so the annotations need their
+    # names imported there, and the secret names have to be literals inside the
+    # handler -- module constants would not resolve. Assert they still match the
+    # names the SECRETS clause above was built from.
+    assert "$$" not in source, "handler source would terminate the $$ body early"
+    for secret in (SECRET_API_KEY, SECRET_BASE_URL):
+        assert f'"{secret}"' in source, f"handler does not read secret {secret}"
+
+    preamble = (
+        "from typing import Optional\n\nfrom snowflake.snowpark import Session\n\n\n"
+    )
+
     # Concatenated, not formatted: the handler source contains braces.
-    script = header + inspect.getsource(nixtla_finetune_handler) + "$$"
+    script = header + preamble + source + "$$"
 
     session.sql(script).collect()
 

--- a/nixtla_tests/snowflake/conftest.py
+++ b/nixtla_tests/snowflake/conftest.py
@@ -501,3 +501,29 @@ def verify_procedures_exist(session: Session, config: DeploymentConfig) -> bool:
     except Exception as e:
         print(f"Procedure verification failed: {e}")
         return False
+
+
+def verify_finetune_procedure_exists(
+    session: Session, config: DeploymentConfig
+) -> bool:
+    """
+    Verify that the finetune stored procedure exists.
+
+    Args:
+        session: Snowflake session
+        config: Deployment configuration
+
+    Returns:
+        True if the finetune procedure exists
+    """
+    # Resolved on argument types, which are unaffected by how the default
+    # value for MAX_SERIES is rendered.
+    full_name = f"{config.prefix}NIXTLA_FINETUNE"
+    signature = "VARCHAR, OBJECT, NUMBER"
+
+    try:
+        session.sql(f"DESC PROCEDURE {full_name}({signature})").collect()
+        return True
+    except Exception as e:
+        print(f"Finetune procedure verification failed: {e}")
+        return False

--- a/nixtla_tests/snowflake/conftest.py
+++ b/nixtla_tests/snowflake/conftest.py
@@ -324,7 +324,7 @@ def deployed_with_api_endpoint(
         deploy_package=True,
         deploy_udtfs=True,
         deploy_procedures=True,
-        deploy_finetune=False,  # Skip finetune to speed up tests
+        deploy_finetune=True,
         deploy_examples=False,  # Load examples separately to get DataFrames
         fallback_package_source=_PROJECT_ROOT,
     )
@@ -490,6 +490,7 @@ def verify_procedures_exist(session: Session, config: DeploymentConfig) -> bool:
         ("NIXTLA_EVALUATE", "VARCHAR, ARRAY, NUMBER"),
         ("NIXTLA_DETECT_ANOMALIES", "VARCHAR, OBJECT, NUMBER"),
         ("NIXTLA_EXPLAIN", "VARCHAR, OBJECT, NUMBER"),
+        ("NIXTLA_FINETUNE", "VARCHAR, OBJECT, NUMBER"),
     ]
 
     try:

--- a/nixtla_tests/snowflake/test_snowflake_deployment.py
+++ b/nixtla_tests/snowflake/test_snowflake_deployment.py
@@ -13,11 +13,13 @@ from snowflake.snowpark import Session
 from nixtla import NixtlaClient
 from nixtla.scripts.snowflake_install_nixtla import (
     DeploymentConfig,
+    create_finetune_sproc,
     get_example_test_cases,
     load_example_datasets,
 )
 from nixtla_tests.snowflake.conftest import (
     SnowflakeTestConfig,
+    verify_finetune_procedure_exists,
     verify_integration_exists,
     verify_network_rule_exists,
     verify_procedures_exist,
@@ -50,6 +52,44 @@ class TestSnowflakeDeployment:
     ):
         """Test full deployment with api.nixtla.io endpoint."""
         _verify_full_deployment(snowflake_session, deployed_with_api_endpoint)
+
+    def test_deploy_finetune_procedure(
+        self,
+        snowflake_session: Session,
+        deployed_with_api_endpoint: DeploymentConfig,
+    ):
+        """Test that NIXTLA_FINETUNE survives DDL compilation.
+
+        Regression test for the ``DEFAULT 1000 :: INT`` cast that Snowpark
+        renders for ``max_series: int = 1000`` and Snowflake rejects with
+        ``000947 invalid default argument expression``.
+
+        Deployed here rather than via ``deploy_finetune=True`` in the
+        module-scoped fixture so a failure surfaces as this one test instead
+        of a setup error on every test in the module.
+        """
+        config = deployed_with_api_endpoint
+
+        # Ensure session is using the correct database and schema context
+        snowflake_session.use_database(config.database)
+        snowflake_session.use_schema(config.schema)
+
+        # Left unguarded on purpose: the SnowparkSQLException is the signal.
+        create_finetune_sproc(snowflake_session, config)
+
+        assert verify_finetune_procedure_exists(snowflake_session, config), (
+            "Finetune procedure not created"
+        )
+
+        ddl = snowflake_session.sql(
+            "SELECT GET_DDL('PROCEDURE', "
+            f"'{config.prefix}NIXTLA_FINETUNE(VARCHAR, OBJECT, NUMBER)')"
+        ).collect()[0][0]
+
+        assert "DEFAULT 1000" in ddl, "MAX_SERIES lost its default value"
+        assert ":: INT" not in ddl, (
+            "MAX_SERIES default is a CAST expression, not a literal"
+        )
 
     def test_example_datasets_loaded(
         self,


### PR DESCRIPTION
## Problem

The Snowflake installer aborts while creating the finetune stored procedure, so `NIXTLA_FINETUNE` and the example datasets never get deployed:

```
000947 (42601): SQL compilation error:
invalid default argument expression CAST(1000 AS NUMBER(38,0))
```

## Cause

`create_finetune_sproc` registered the procedure with Snowpark's `@sproc` decorator. Snowpark renders Python defaults through `to_sql()`, whose `_IntegralType` branch unconditionally appends a cast, so `max_series: int = 1000` became `DEFAULT 1000 :: INT` — and Snowflake accepts only a bare literal there. (`params: Optional[dict] = None` renders as a plain `NULL`, which is why `MAX_SERIES` was the only argument that failed.)

Not a version regression: the rendering is identical across Snowpark 1.21.0–1.52.0, so pinning or upgrading Snowpark does not help.

## Fix

Emit the DDL directly and ship the handler as source instead of a cloudpickle blob, following the existing `TEMPLATE_SP` pattern:

```sql
"MAX_SERIES" NUMBER(38,0) DEFAULT 1000
```

Defaults now live only in the DDL — the handler signature declares none, since Snowflake resolves them at `CALL` time and always passes every argument. The body opens with a small import preamble so its annotations resolve in the module Snowflake execs it in.

Fixed as a consequence:

- Arguments are named `INPUT_DATA`/`PARAMS`/`MAX_SERIES` instead of `arg1`/`arg2`/`arg3`, so the named-argument `CALL` documented in `nbs/docs/deployment/3_snowflake.ipynb` works for the first time.
- Drops the implicit `cloudpickle>=3.1.1` requirement Snowpark injected.
- Public `CALL` signature is unchanged; 1-, 2- and 3-argument calls all still work.

## Behaviour change: `finetune_steps` default

The handler used to derive `finetune_steps` from the data when the caller omitted it:

```python
if "finetune_steps" not in params:
    params["finetune_steps"] = train_data["unique_id"].nunique()
```

This conflated gradient steps with series count. One series meant one step (and zero series meant zero steps — a silent no-op that still returned a model id), while a large table meant up to `MAX_SERIES` = 1000 steps, ~100× the library default, with cost scaling to match. It also made the same `CALL` non-reproducible as data grew.

Removed, so `NixtlaClient.finetune`'s own `finetune_steps=10` applies. Callers wanting a specific value use the documented route, `PARAMS => OBJECT_CONSTRUCT('finetune_steps', 100)`. Docs updated. No existing callers are affected — the procedure has never deployed successfully.

## Tests

`deploy_finetune=False` had been set in the test fixture since the Snowflake integration first landed, so this path had never run in CI. It is now enabled, `NIXTLA_FINETUNE` is checked by `verify_procedures_exist`, and `test_deploy_finetune_procedure` asserts via `GET_DDL` that the default is a bare literal rather than a cast.
