### PR TITLE
[PRE-RELEASE] v0.9.0.dev0 of Nixtla client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "nixtla"
-version = "0.8.0"
+version = "0.9.0.dev0"
 description = "Python SDK for Nixtla API (TimeGPT)"
 authors = [
     {name = "Nixtla", email = "business@nixtla.io"}

--- a/uv.lock
+++ b/uv.lock
@@ -2932,7 +2932,7 @@ wheels = [
 
 [[package]]
 name = "nixtla"
-version = "0.8.0"
+version = "0.9.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
Bumps the client version to `0.9.0.dev0` in `pyproject.toml` and `uv.lock` so a pre-release can be cut from `main`. No functional changes.

## Included since v0.8.0

**Features**
* `execute_step` support in `NixtlaClient` (#864)
* Async `forecast`, `cross_validation` and `finetune` methods (#847)
* Start datetime information (#859)

**Fixes**
* Incorrect actual values in cross-validation output (#866)
* Snowflake finetune procedure failing to deploy on an invalid default argument (#867)

**Chores**
* Dependabot alerts #120 and #126–#130 — ray, setuptools, aiohttp, cryptography (#851, #854); CI dependency bumps (#848)
* Docs: OpenAPI sync for nixtla-engine v0.3.1, style consolidation, stale-slug redirects

## Releasing

Once this merges, tag the resulting `main` commit as `v0.9.0.dev0` and push it — `python-publish.yml` fires on `v*` tags and publishes to PyPI. The tag must sit on the merged `main` commit; the workflow asserts the tag commit is an ancestor of `origin/main`.
