### PR TITLE
feat: snowflake demo helpers and collateral + unpin claude

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
                 "charliermarsh.ruff@2025.22.0",
                 "GitHub.copilot",
                 "tamasfe.even-better-toml",
-                "anthropic.claude-code@1.0.127"
+                "anthropic.claude-code"
             ]
         }
     },

--- a/nixtla/snowflake/__init__.py
+++ b/nixtla/snowflake/__init__.py
@@ -1,0 +1,13 @@
+"""Helpers for working with the Snowflake TimeGPT integration from Python."""
+
+from nixtla.snowflake.anomaly import (
+    detect_anomalies,
+    load_actuals,
+    to_anomalies_df,
+)
+
+__all__ = [
+    "detect_anomalies",
+    "load_actuals",
+    "to_anomalies_df",
+]

--- a/nixtla/snowflake/anomaly.py
+++ b/nixtla/snowflake/anomaly.py
@@ -1,0 +1,199 @@
+"""Plot Snowflake TimeGPT anomaly results with ``nixtla_client``.
+
+``NIXTLA_DETECT_ANOMALIES`` returns the columns::
+
+    UNIQUE_ID  DS  Y  TIMEGPT  ANOMALY  TIMEGPT_LO  TIMEGPT_HI
+
+which differ from what ``NixtlaClient.detect_anomalies`` returns in three ways:
+Snowflake uppercases the names, ``ANOMALY`` comes back as a string, and the
+level is stripped from the interval columns (the client names them
+``TimeGPT-lo-99`` / ``TimeGPT-hi-99``). Because the level is gone from the
+data, it has to be supplied by the caller -- it is the level the SQL ran at.
+
+Renaming is all that is needed. ``nixtla_client.plot`` recognises an
+``anomaly`` column and reads the level, the flags and the model name straight
+off the frame, so no plotting wrapper is required here.
+
+Examples
+--------
+>>> from anomaly import detect_anomalies, load_actuals
+>>> table = "DEMO.PUBLIC.EXAMPLE_ANOMALY_DATA"
+>>> actuals = load_actuals(session, table)
+>>> nixtla_client.plot(actuals)
+>>> anomalies = detect_anomalies(session, table, level=99, freq="D")
+>>> nixtla_client.plot(actuals, anomalies)
+
+For a result you obtained yourself -- a SQL cell's ``dataframe_1``, say -- skip
+``detect_anomalies`` and rename in place:
+
+>>> nixtla_client.plot(actuals, to_anomalies_df(dataframe_1, level=99))
+
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Union
+
+import pandas as pd
+
+# Union (not `|`) because these aliases are evaluated at runtime and
+# warehouse-runtime notebooks default to Python 3.9.
+Level = Union[int, float]  # noqa: UP007
+
+_TRUTHY = {"true", "t", "1", "yes"}
+_ACTUALS = ["unique_id", "ds", "y"]
+_PROCEDURE = "NIXTLA_DETECT_ANOMALIES"
+
+
+def _to_pandas(result: Any) -> pd.DataFrame:
+    """Convert a Snowpark result to pandas and strip quoted identifiers.
+
+    Snowpark leaves the literal quotes on quoted column names, so ``DS`` can
+    arrive as ``'"DS"'``.
+    """
+    df = result.to_pandas() if hasattr(result, "to_pandas") else result.copy()
+    df.columns = [str(c).strip().strip('"').strip() for c in df.columns]
+    return df
+
+
+def _finalize(df: pd.DataFrame, expected: list[str]) -> pd.DataFrame:
+    """Check the renamed columns, type ``ds``, and sort by series and time."""
+    missing = [c for c in expected if c not in df.columns]
+    if missing:
+        raise KeyError(f"missing {missing}; got {list(df.columns)}")
+    df["ds"] = pd.to_datetime(df["ds"])
+    return df.sort_values(["unique_id", "ds"], ignore_index=True)
+
+
+def _qualify(session: Any, procedure: str | None) -> str:
+    """Qualify the procedure with the session's current database and schema."""
+    if procedure is not None:
+        return procedure
+    database, schema = session.get_current_database(), session.get_current_schema()
+    if not (database and schema):
+        raise ValueError(
+            "the session has no current database and schema, so the procedure "
+            f"cannot be located; pass procedure='<db>.<schema>.{_PROCEDURE}'"
+        )
+    # Snowpark returns both already quoted, which keeps a lowercase name intact.
+    return f"{database}.{schema}.{_PROCEDURE}"
+
+
+def load_actuals(session: Any, table: str) -> pd.DataFrame:
+    """Read the input table as actuals, named the way ``plot`` expects.
+
+    Parameters
+    ----------
+    session : snowflake.snowpark.Session
+        Active Snowpark session.
+    table : str
+        Fully qualified table name.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns ``unique_id``, ``ds``, ``y``, sorted by series and time.
+
+    """
+    df = _to_pandas(session.table(table))
+    df = df.rename(columns={c: c.lower() for c in df.columns})
+    return _finalize(df, _ACTUALS)
+
+
+def to_anomalies_df(result: Any, level: Level) -> pd.DataFrame:
+    """Rename a ``NIXTLA_DETECT_ANOMALIES`` result to the client's own names.
+
+    Parameters
+    ----------
+    result : snowflake.snowpark.DataFrame or pandas.DataFrame
+        The procedure's output, however you obtained it.
+    level : int or float
+        The level the SQL ran at. The procedure drops it from the interval
+        column names, so it cannot be recovered from the data; passing the
+        wrong one mislabels the band that gets plotted.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns ``unique_id``, ``ds``, ``y``, ``TimeGPT``, ``anomaly`` (bool)
+        and ``TimeGPT-lo-<level>`` / ``TimeGPT-hi-<level>``.
+
+    Raises
+    ------
+    KeyError
+        If the frame is not a detection result -- usually a sign the procedure
+        returned a status row rather than its table.
+
+    """
+    renames = {
+        "UNIQUE_ID": "unique_id",
+        "DS": "ds",
+        "Y": "y",
+        "TIMEGPT": "TimeGPT",
+        "ANOMALY": "anomaly",
+        "TIMEGPT_LO": f"TimeGPT-lo-{level}",
+        "TIMEGPT_HI": f"TimeGPT-hi-{level}",
+    }
+    df = _to_pandas(result)
+    df = df.rename(
+        columns={c: renames[c.upper()] for c in df.columns if c.upper() in renames}
+    )
+    bounds = [renames["TIMEGPT_LO"], renames["TIMEGPT_HI"]]
+    df = _finalize(df, [*_ACTUALS, "TimeGPT", "anomaly", *bounds])
+    df["anomaly"] = df["anomaly"].astype(str).str.strip().str.lower().isin(_TRUTHY)
+    return df
+
+
+def detect_anomalies(
+    session: Any,
+    table: str,
+    level: Level = 99,
+    *,
+    procedure: str | None = None,
+    **params: Any,
+) -> pd.DataFrame:
+    """Run ``NIXTLA_DETECT_ANOMALIES`` and return a client-shaped frame.
+
+    Parameters
+    ----------
+    session : snowflake.snowpark.Session
+        Active Snowpark session.
+    table : str
+        Fully qualified name of the input table.
+    level : int or float, default 99
+        Confidence level. Whole floats are sent as integers so that the
+        procedure's interval columns come back populated.
+    procedure : str, optional
+        Fully qualified procedure name. Defaults to ``NIXTLA_DETECT_ANOMALIES``
+        in the session's current database and schema; pass it explicitly when
+        the procedure was installed somewhere other than where the notebook is
+        pointed.
+    **params
+        Further entries for the procedure's ``PARAMS`` object, e.g. ``freq``,
+        ``model`` or ``finetuned_model_id``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Ready for ``nixtla_client.plot(actuals, anomalies)``.
+
+    """
+    if isinstance(level, float) and level.is_integer():
+        level = int(level)
+    payload = json.dumps({"level": level, **params}).replace("'", "''")
+    sql = (
+        f"CALL {_qualify(session, procedure)}("
+        f"INPUT_DATA => '{table}', PARAMS => PARSE_JSON('{payload}'))"
+    )
+    try:
+        raw = session.sql(sql).to_pandas()
+    except Exception:
+        # A procedure returning a table sometimes has to be read back out of
+        # the result cache instead. This re-runs the CALL, so detection is
+        # billed twice on the (rare) attempts that land here.
+        session.sql(sql).collect()
+        raw = session.sql(
+            "SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))"
+        ).to_pandas()
+    return to_anomalies_df(raw, level)

--- a/nixtla/snowflake/demo_anomaly.ipynb
+++ b/nixtla/snowflake/demo_anomaly.ipynb
@@ -1,0 +1,245 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c57c4ccf",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "# Anomaly detection in Snowflake, plotted with `nixtla_client`\n",
+    "\n",
+    "Detection runs in Snowflake through `NIXTLA_DETECT_ANOMALIES`; the charts are\n",
+    "drawn locally by `nixtla_client.plot`, which runs entirely in this notebook and\n",
+    "makes no API call.\n",
+    "\n",
+    "The procedure returns the same information as `NixtlaClient.detect_anomalies`\n",
+    "under different column names, so `anomaly.py` renames them back. Add that file\n",
+    "to this notebook (**Files** in the sidebar) before running the next cell."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adf357b2",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2722b67",
+   "metadata": {
+    "language": "python"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from nixtla import NixtlaClient\n",
+    "except ImportError:\n",
+    "    !pip install -q nixtla\n",
+    "    from nixtla import NixtlaClient\n",
+    "\n",
+    "from anomaly import detect_anomalies, load_actuals, to_anomalies_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69baed48",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Instantiate NixtlaClient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fec73d75",
+   "metadata": {
+    "language": "python",
+    "name": "instantiate",
+    "title": "instantiate"
+   },
+   "outputs": [],
+   "source": [
+    "from snowflake.snowpark.secrets import get_generic_secret_string\n",
+    "\n",
+    "nixtla_client = NixtlaClient(\n",
+    "    api_key=get_generic_secret_string(\"demo/public/nixtla_api_key\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74de9fdf",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## The data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2469c939",
+   "metadata": {
+    "language": "python"
+   },
+   "outputs": [],
+   "source": [
+    "from snowflake.snowpark.context import get_active_session\n",
+    "\n",
+    "session = get_active_session()\n",
+    "\n",
+    "INPUT_TABLE = \"DEMO.PUBLIC.EXAMPLE_ANOMALY_DATA\"\n",
+    "FREQ = \"D\"\n",
+    "MODEL = \"timegpt-1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0a4756b",
+   "metadata": {
+    "language": "python"
+   },
+   "outputs": [],
+   "source": [
+    "actuals = load_actuals(session, INPUT_TABLE)\n",
+    "nixtla_client.plot(actuals)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc0b64ed",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Detect anomalies\n",
+    "\n",
+    "`detect_anomalies` calls the procedure and hands back a frame shaped like the\n",
+    "client's own output. `plot` reads the level, the flags and the model name off\n",
+    "that frame, so nothing else needs passing.\n",
+    "\n",
+    "The procedure is looked up as `NIXTLA_DETECT_ANOMALIES` in this notebook's\n",
+    "current database and schema. If you installed it elsewhere, add\n",
+    "`procedure=\"<db>.<schema>.NIXTLA_DETECT_ANOMALIES\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d98723c5",
+   "metadata": {
+    "language": "python"
+   },
+   "outputs": [],
+   "source": [
+    "anomalies = detect_anomalies(session, INPUT_TABLE, level=99, procedure=\"DEMO.PUBLIC.NIXTLA_DETECT_ANOMALIES\", freq=FREQ, model=MODEL)\n",
+    "anomalies.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2846bdfd",
+   "metadata": {
+    "language": "python"
+   },
+   "outputs": [],
+   "source": [
+    "nixtla_client.plot(actuals, anomalies)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40e4b04b",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### A different confidence level\n",
+    "\n",
+    "A wider interval flags fewer points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92f9dd00",
+   "metadata": {
+    "language": "python"
+   },
+   "outputs": [],
+   "source": [
+    "wider = detect_anomalies(session, INPUT_TABLE, level=99.9, procedure=\"DEMO.PUBLIC.NIXTLA_DETECT_ANOMALIES\", freq=FREQ, model=MODEL)\n",
+    "\n",
+    "for name, df in [(\"99\", anomalies), (\"99.9\", wider)]:\n",
+    "    print(f\"level={name:<5} {int(df['anomaly'].sum())} anomalies of {len(df)} points\")\n",
+    "\n",
+    "nixtla_client.plot(actuals, wider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc9f4727",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Plotting a result from a SQL cell\n",
+    "\n",
+    "A SQL cell exposes its result to Python under the pointer name shown on the\n",
+    "cell -- `dataframe_1` for the first one, double-click to rename. `to_anomalies_df`\n",
+    "renames the columns the same way `detect_anomalies` does; pass the level the SQL\n",
+    "ran at, since the procedure strips it from the interval column names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f0cb925",
+   "metadata": {
+    "language": "sql"
+   },
+   "outputs": [],
+   "source": [
+    "CALL DEMO.PUBLIC.NIXTLA_DETECT_ANOMALIES(\n",
+    "    INPUT_DATA => 'DEMO.PUBLIC.EXAMPLE_ANOMALY_DATA',\n",
+    "    PARAMS => OBJECT_CONSTRUCT(\n",
+    "        'level', 99.9,\n",
+    "        'freq',  'D',\n",
+    "        'model', 'timegpt-1'\n",
+    "    )\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90294035",
+   "metadata": {
+    "language": "python"
+   },
+   "outputs": [],
+   "source": [
+    "nixtla_client.plot(actuals, to_anomalies_df(dataframe_1, level=99.9))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Jupyter Notebook",
+   "name": "jupyter"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
* the snowflake integration provides output column names that are in a different format to the client. 
  * added some helpers to synchronize the two. 
  * also added a demo/visualization notebook that utilizes the client for plotting the results since native snowflake visualization was lacking.  
* unpins claude so we use the latest version always - which has the latest features.
 