### PR TITLE
[PRE-RELEASE] v0.9.0.dev1 of Nixtla client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "nixtla"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 description = "Python SDK for Nixtla API (TimeGPT)"
 authors = [
     {name = "Nixtla", email = "business@nixtla.io"}

--- a/uv.lock
+++ b/uv.lock
@@ -2932,7 +2932,7 @@ wheels = [
 
 [[package]]
 name = "nixtla"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
Bumps the client version to `0.9.0.dev1` in `pyproject.toml` and `uv.lock` so a pre-release can be cut from `main`. No functional changes.

## Included since v0.9.0.dev0

* Snowflake demo helpers — new `nixtla/snowflake` package with `anomaly.py` and `demo_anomaly.ipynb`; devcontainer unpins claude (#870)
* Docs: OpenAPI sync for nixtla-engine v0.4.0 (#869)

## Releasing

Once this merges, tag the resulting `main` commit as `v0.9.0.dev1` and push it — `python-publish.yml` fires on `v*` tags and publishes to PyPI. The tag must sit on the merged `main` commit; the workflow asserts the tag commit is an ancestor of `origin/main`.
