### PR TITLE
[FEAT] Add `submit_anomaly_detection_job` for asynchronous anomaly detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- New `submit_anomaly_detection_job` submits online anomaly detection as a server-side job and returns a `Job` handle, the asynchronous counterpart to `detect_anomalies_online`. `num_partitions` is not supported; use `detect_anomalies_online` for distributed dataframes.
+- `detect_anomalies_online` accepts `finetuned_model_id` and `model_parameters`, which the API already supported but the client did not expose.
 - Async job submissions, including `execute_step`, retry only connection failures and HTTP 429 responses. Read timeouts and gateway errors now fail immediately to avoid creating duplicate jobs. Retry sleeps respect the remaining `max_wait_time` budget.
 - Async partitioned requests share a limit of five concurrent jobs. A partition failure cancels sibling jobs and stops queued submissions. Synchronous partitioned requests also stop queued work after a failure.
 - `simulate` and `explain` use `AsyncJobTimeoutError` and `AsyncJobCancelledError`, consistently with existing async endpoints. `AsyncJobError.error` preserves the original server error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - New `submit_anomaly_detection_job` submits online anomaly detection as a server-side job and returns a `Job` handle, the asynchronous counterpart to `detect_anomalies_online`. `num_partitions` is not supported; use `detect_anomalies_online` for distributed dataframes.
-- `detect_anomalies_online` accepts `finetuned_model_id` and `model_parameters`, which the API already supported but the client did not expose.
+- `detect_anomalies_online` accepts `finetuned_model_id` and `model_parameters`, which the API already supported but the client did not expose. Both are inserted mid-signature to match the parameter order used by `forecast` and `cross_validation`, so callers passing arguments **positionally** past `finetune_loss` must switch to keywords; its request body now also always carries `finetuned_model_id` (previously omitted when unset).
+- Async job results are validated before parsing: a job that reports success with a missing or non-object result now raises `AsyncJobError` instead of a `TypeError`, for every `submit_*_job` method.
 - Async job submissions, including `execute_step`, retry only connection failures and HTTP 429 responses. Read timeouts and gateway errors now fail immediately to avoid creating duplicate jobs. Retry sleeps respect the remaining `max_wait_time` budget.
 - Async partitioned requests share a limit of five concurrent jobs. A partition failure cancels sibling jobs and stops queued submissions. Synchronous partitioned requests also stop queued work after a failure.
 - `simulate` and `explain` use `AsyncJobTimeoutError` and `AsyncJobCancelledError`, consistently with existing async endpoints. `AsyncJobError.error` preserves the original server error.

--- a/nixtla/async_job.py
+++ b/nixtla/async_job.py
@@ -102,8 +102,8 @@ class AsyncJobCancelledError(Exception):
 
 class Job:
     """Handle to a server-side async job submitted via `submit_forecast_job`,
-    `submit_finetune_job`, `submit_cross_validation_job`, or
-    `submit_execute_step_job`.
+    `submit_finetune_job`, `submit_cross_validation_job`,
+    `submit_anomaly_detection_job`, or `submit_execute_step_job`.
 
     `status` queries the server for the job's current status; call `wait()`
     to block until it reaches a terminal state and get its result, or

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -4517,10 +4517,12 @@ class NixtlaClient:
         finetune_steps: _NonNegativeInt,
         finetune_depth: _FinetuneDepth,
         finetune_loss: _Loss,
+        finetuned_model_id: Optional[str],
         hist_exog_list: Optional[list[str]],
         date_features: Union[bool, list[str]],
         date_features_to_one_hot: Union[bool, list[str]],
         model: _Model,
+        model_parameters: _ExtraParamDataType,
         refit: bool,
         num_partitions: Optional[int],
         multivariate: bool,
@@ -4556,10 +4558,12 @@ class NixtlaClient:
                 finetune_steps=finetune_steps,
                 finetune_loss=finetune_loss,
                 finetune_depth=finetune_depth,
+                finetuned_model_id=finetuned_model_id,
                 hist_exog_list=hist_exog_list,
                 date_features=date_features,
                 date_features_to_one_hot=date_features_to_one_hot,
                 model=model,
+                model_parameters=model_parameters,
                 refit=refit,
                 num_partitions=None,
                 multivariate=multivariate,
@@ -4568,6 +4572,127 @@ class NixtlaClient:
             as_fugue=True,
         )
         return fa.get_native_as_df(result_df)
+
+    def _prepare_online_anomaly_detection(
+        self,
+        df: DFType,
+        h: _PositiveInt,
+        detection_size: _PositiveInt,
+        threshold_method: _ThresholdMethod,
+        freq: Optional[_Freq],
+        id_col: str,
+        time_col: str,
+        target_col: str,
+        level: Union[int, float],
+        clean_ex_first: bool,
+        step_size: Optional[_PositiveInt],
+        finetune_steps: _NonNegativeInt,
+        finetune_depth: _FinetuneDepth,
+        finetune_loss: _Loss,
+        finetuned_model_id: Optional[str],
+        hist_exog_list: Optional[list[str]],
+        date_features: Union[bool, list[str]],
+        date_features_to_one_hot: Union[bool, list[str]],
+        model: _Model,
+        model_parameters: _ExtraParamDataType,
+        refit: bool,
+        multivariate: bool,
+    ) -> tuple[dict[str, Any], Callable[[dict[str, Any]], Any]]:
+        """Build the online anomaly detection payload and its result parser.
+
+        Shared by `detect_anomalies_online` and `submit_anomaly_detection_job` so the
+        two paths cannot drift: the payload is identical and `parse_result` assembles
+        the response the same way whether it arrived inline or from a finished job.
+        """
+        self.__dict__.pop("weights_x", None)
+        model = self._maybe_override_model(model)
+        logger.info("Validating inputs...")
+        df, _, drop_id, freq = self._run_validations(
+            df=df,
+            X_df=None,
+            id_col=id_col,
+            time_col=time_col,
+            target_col=target_col,
+            validate_api_key=False,
+            freq=freq,
+        )
+        logger.info("Preprocessing dataframes...")
+        processed, _, x_cols, _ = _preprocess(
+            df=df,
+            X_df=None,
+            h=0,
+            freq=freq,
+            date_features=date_features,
+            date_features_to_one_hot=date_features_to_one_hot,
+            id_col=id_col,
+            time_col=time_col,
+            target_col=target_col,
+        )
+        standard_freq = _standardize_freq(freq, processed)
+        targets = _extract_target_array(df, target_col)
+        times = df[time_col].to_numpy()
+        if processed.sort_idxs is not None:
+            targets = targets[processed.sort_idxs]
+            times = times[processed.sort_idxs]
+        X, hist_exog = _process_exog_features(processed.data, x_cols, hist_exog_list)
+        sizes = np.diff(processed.indptr)
+        if np.all(sizes <= 6 * detection_size):
+            logger.warn(
+                "Detection size is large. Using the entire series to compute the anomaly threshold..."
+            )
+        online_series: dict[str, Any] = {
+            "y": processed.data[:, 0],
+            "sizes": sizes,
+            "X": X,
+        }
+        # `times` is already sorted to match the payload row order
+        start_datetime = _times_to_iso(
+            times[processed.indptr[:-1]], _time_col_tz(df, time_col)
+        )
+        if start_datetime is not None:
+            online_series["start_datetime"] = start_datetime
+        payload = {
+            "series": online_series,
+            "h": h,
+            "detection_size": detection_size,
+            "threshold_method": threshold_method,
+            "model": model,
+            "freq": standard_freq,
+            "clean_ex_first": clean_ex_first,
+            "level": level,
+            "step_size": step_size,
+            "finetune_steps": finetune_steps,
+            "finetune_loss": finetune_loss,
+            "finetune_depth": finetune_depth,
+            "finetuned_model_id": finetuned_model_id,
+            "refit": refit,
+            "hist_exog": hist_exog,
+            "multivariate": multivariate,
+        }
+        if model_parameters is not None:
+            payload.update({"model_parameters": model_parameters})
+
+        def parse_result(resp: dict[str, Any]) -> Any:
+            # assemble result
+            idxs = np.array(resp["idxs"], dtype=np.int64)
+            sizes = np.array(resp["sizes"], dtype=np.int64)
+            out = type(df)(
+                {
+                    id_col: ufp.repeat(processed.uids, sizes),
+                    time_col: times[idxs],
+                    target_col: targets[idxs],
+                }
+            )
+            out = ufp.assign_columns(out, "TimeGPT", resp["mean"])
+            out = ufp.assign_columns(out, "anomaly", resp["anomaly"])
+            out = ufp.assign_columns(out, "anomaly_score", resp["anomaly_score"])
+            if threshold_method == "multivariate":
+                out = ufp.assign_columns(
+                    out, "accumulated_anomaly_score", resp["accumulated_anomaly_score"]
+                )
+            return _maybe_add_intervals(out, resp["intervals"])
+
+        return payload, parse_result
 
     def detect_anomalies_online(
         self,
@@ -4585,10 +4710,12 @@ class NixtlaClient:
         finetune_steps: _NonNegativeInt = 0,
         finetune_depth: _FinetuneDepth = 1,
         finetune_loss: _Loss = "default",
+        finetuned_model_id: Optional[str] = None,
         hist_exog_list: Optional[list[str]] = None,
         date_features: Union[bool, list[str]] = False,
         date_features_to_one_hot: Union[bool, list[str]] = False,
         model: _Model = "timegpt-2.1",
+        model_parameters: _ExtraParamDataType = None,
         refit: bool = False,
         num_partitions: Optional[_PositiveInt] = None,
         multivariate: bool = False,
@@ -4646,6 +4773,8 @@ class NixtlaClient:
             finetune_loss (str): Loss function to use for finetuning.
                 Options are: `default`, `mae`, `mse`, `rmse`, `mape`, and
                 `smape`. Defaults to 'default'.
+            finetuned_model_id (str, optional): ID of previously fine-tuned model
+                to use. Defaults to None.
             hist_exog_list (list[str], optional): Column names of the historical
                 exogenous features. Defaults to None.
             date_features (bool or list[str] or callable, optional): Features
@@ -4664,6 +4793,8 @@ class NixtlaClient:
                 `timegpt-1-long-horizon` for forecasting if you want to
                 predict more than one seasonal period given the frequency of
                 your data. Defaults to 'timegpt-2.1'.
+            model_parameters (dict): The dictionary settings that determine
+                the behavior of the model. Default is None.
             refit (bool, optional): Fine-tune the model in each window. If
                 False, only fine-tunes on the first window. Only used if
                 finetune_steps > 0. Defaults to False.
@@ -4683,6 +4814,7 @@ class NixtlaClient:
             pandas, polars, dask or spark DataFrame or ray Dataset:
                 DataFrame with anomalies flagged by TimeGPT.
         """
+        extra_param_checker.validate_python(model_parameters)
         if not isinstance(df, (pd.DataFrame, pl_DataFrame)):
             return self._distributed_detect_anomalies_online(
                 df=df,
@@ -4699,10 +4831,12 @@ class NixtlaClient:
                 finetune_steps=finetune_steps,
                 finetune_depth=finetune_depth,
                 finetune_loss=finetune_loss,
+                finetuned_model_id=finetuned_model_id,
                 hist_exog_list=hist_exog_list,
                 date_features=date_features,
                 date_features_to_one_hot=date_features_to_one_hot,
                 model=model,
+                model_parameters=model_parameters,
                 refit=refit,
                 num_partitions=num_partitions,
                 multivariate=multivariate,
@@ -4717,71 +4851,31 @@ class NixtlaClient:
                 "Either set threshold_method to univariate "
                 "or set num_partitions to None."
             )
-        self.__dict__.pop("weights_x", None)
-        model = self._maybe_override_model(model)
-        logger.info("Validating inputs...")
-        df, _, drop_id, freq = self._run_validations(
+        payload, parse_result = self._prepare_online_anomaly_detection(
             df=df,
-            X_df=None,
+            h=h,
+            detection_size=detection_size,
+            threshold_method=threshold_method,
+            freq=freq,
             id_col=id_col,
             time_col=time_col,
             target_col=target_col,
-            validate_api_key=False,
-            freq=freq,
-        )
-        logger.info("Preprocessing dataframes...")
-        processed, _, x_cols, _ = _preprocess(
-            df=df,
-            X_df=None,
-            h=0,
-            freq=freq,
+            level=level,
+            clean_ex_first=clean_ex_first,
+            step_size=step_size,
+            finetune_steps=finetune_steps,
+            finetune_depth=finetune_depth,
+            finetune_loss=finetune_loss,
+            finetuned_model_id=finetuned_model_id,
+            hist_exog_list=hist_exog_list,
             date_features=date_features,
             date_features_to_one_hot=date_features_to_one_hot,
-            id_col=id_col,
-            time_col=time_col,
-            target_col=target_col,
+            model=model,
+            model_parameters=model_parameters,
+            refit=refit,
+            multivariate=multivariate,
         )
-        standard_freq = _standardize_freq(freq, processed)
-        targets = _extract_target_array(df, target_col)
-        times = df[time_col].to_numpy()
-        if processed.sort_idxs is not None:
-            targets = targets[processed.sort_idxs]
-            times = times[processed.sort_idxs]
-        X, hist_exog = _process_exog_features(processed.data, x_cols, hist_exog_list)
-        sizes = np.diff(processed.indptr)
-        if np.all(sizes <= 6 * detection_size):
-            logger.warn(
-                "Detection size is large. Using the entire series to compute the anomaly threshold..."
-            )
         logger.info("Calling Online Anomaly Detector Endpoint...")
-        online_series: dict[str, Any] = {
-            "y": processed.data[:, 0],
-            "sizes": sizes,
-            "X": X,
-        }
-        # `times` is already sorted to match the payload row order
-        start_datetime = _times_to_iso(
-            times[processed.indptr[:-1]], _time_col_tz(df, time_col)
-        )
-        if start_datetime is not None:
-            online_series["start_datetime"] = start_datetime
-        payload = {
-            "series": online_series,
-            "h": h,
-            "detection_size": detection_size,
-            "threshold_method": threshold_method,
-            "model": model,
-            "freq": standard_freq,
-            "clean_ex_first": clean_ex_first,
-            "level": level,
-            "step_size": step_size,
-            "finetune_steps": finetune_steps,
-            "finetune_loss": finetune_loss,
-            "finetune_depth": finetune_depth,
-            "refit": refit,
-            "hist_exog": hist_exog,
-            "multivariate": multivariate,
-        }
         with self._make_client(**self._client_kwargs) as client:
             if num_partitions is None:
                 resp = self._make_request_with_retries(
@@ -4792,25 +4886,171 @@ class NixtlaClient:
                 resp = self._make_partitioned_requests(
                     client, "v2/online_anomaly_detection", payloads
                 )
+        return parse_result(resp)
 
-        # assemble result
-        idxs = np.array(resp["idxs"], dtype=np.int64)
-        sizes = np.array(resp["sizes"], dtype=np.int64)
-        out = type(df)(
-            {
-                id_col: ufp.repeat(processed.uids, sizes),
-                time_col: times[idxs],
-                target_col: targets[idxs],
-            }
+    def submit_anomaly_detection_job(
+        self,
+        df: DFType,
+        h: _PositiveInt,
+        detection_size: _PositiveInt,
+        threshold_method: _ThresholdMethod = "univariate",
+        freq: Optional[_Freq] = None,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+        level: Union[int, float] = 99,
+        clean_ex_first: bool = True,
+        step_size: Optional[_PositiveInt] = None,
+        finetune_steps: _NonNegativeInt = 0,
+        finetune_depth: _FinetuneDepth = 1,
+        finetune_loss: _Loss = "default",
+        finetuned_model_id: Optional[str] = None,
+        hist_exog_list: Optional[list[str]] = None,
+        date_features: Union[bool, list[str]] = False,
+        date_features_to_one_hot: Union[bool, list[str]] = False,
+        model: _Model = "timegpt-2.1",
+        model_parameters: _ExtraParamDataType = None,
+        refit: bool = False,
+        multivariate: bool = False,
+        job_timeout_seconds: Optional[int] = None,
+    ) -> Job:
+        """Submit an online anomaly detection job to run asynchronously.
+
+        Unlike `detect_anomalies_online()`, this does not block until the job
+        finishes. It submits the job and immediately returns a `Job` handle;
+        call `job.wait()` to poll until it completes and get the resulting
+        DataFrame, or `job.cancel()` to request that the server stop it.
+
+        Not supported in this version: `num_partitions` (distributed/threaded
+        fan-out). Use `detect_anomalies_online()` for that.
+
+        Args:
+            df (pandas or polars DataFrame):
+                The DataFrame on which the function will operate. Expected
+                to contain at least the following columns:
+                - time_col:
+                    Column name in `df` that contains the time indices of the
+                    time series. This is typically a datetime column with
+                    regular intervals, e.g., hourly, daily, monthly data
+                    points.
+                - target_col:
+                    Column name in `df` that contains the target variable of
+                    the time series, i.e., the variable we wish to predict or
+                    analyze.
+                - id_col:
+                    Column name in `df` that identifies unique time series.
+                    Each unique value in this column corresponds to a unique
+                    time series.
+
+            h (int): Forecast horizon.
+            detection_size (int): The length of the sequence where anomalies
+                will be detected starting from the end of the dataset.
+            threshold_method (str, optional): The method used to calculate the
+                intervals for anomaly detection. Use `univariate` to flag
+                anomalies independently for each series in the dataset.
+                Use `multivariate` to have a global threshold across all series
+                in the dataset. For this method, all series must have the same
+                length. Defaults to 'univariate'.
+            freq (str, optional): Frequency of the data. By default, the freq
+                will be inferred automatically. See [pandas' available frequencies](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases).
+            id_col (str, optional): Column that identifies each series.
+                Defaults to 'unique_id'
+            time_col (str, optional): Column that identifies each timestep,
+                its values can be timestamps or integers. Defaults to 'ds'.
+            target_col (str, optional): Column that contains the target.
+                Defaults to 'y'.
+            level (float, optional):
+                Confidence level between 0 and 100 for detecting the anomalies.
+                Defaults to 99.
+            clean_ex_first (bool, optional): Clean exogenous signal before
+                making forecasts using TimeGPT. Defaults to True.
+            step_size (int, optional): Step size between each cross validation
+                window. If None it will be equal to `h`. Defaults to None.
+            finetune_steps (int): Number of steps used to finetune TimeGPT in
+                the new data. Defaults to 0.
+            finetune_depth (int): The depth of the finetuning. Uses a scale
+                from 1 to 5, where 1 means little finetuning, and 5 means that
+                the entire model is finetuned. Defaults to 1.
+            finetune_loss (str): Loss function to use for finetuning.
+                Options are: `default`, `mae`, `mse`, `rmse`, `mape`, and
+                `smape`. Defaults to 'default'.
+            finetuned_model_id (str, optional): ID of previously fine-tuned model
+                to use. Defaults to None.
+            hist_exog_list (list[str], optional): Column names of the historical
+                exogenous features. Defaults to None.
+            date_features (bool or list[str] or callable, optional): Features
+                computed from the dates. Can be pandas date attributes
+                or functions that will take the dates as input. If True
+                automatically adds most used date features for the
+                frequency of `df`. Defaults to False.
+            date_features_to_one_hot (bool or list[str]): Apply one-hot
+                encoding to these date features. If
+                `date_features=True`, then all date features are
+                one-hot encoded by default. Defaults to False.
+            model (str, optional): Model to use as a string. Options are:
+                `timegpt-1`, and `timegpt-1-long-horizon`, `timegpt-2`,
+                `timegpt-2-mini`, `timegpt-2-pro`, `timegpt-2.1`.
+                We recommend using
+                `timegpt-1-long-horizon` for forecasting if you want to
+                predict more than one seasonal period given the frequency of
+                your data. Defaults to 'timegpt-2.1'.
+            model_parameters (dict): The dictionary settings that determine
+                the behavior of the model. Default is None.
+            refit (bool, optional): Fine-tune the model in each window. If
+                False, only fine-tunes on the first window. Only used if
+                finetune_steps > 0. Defaults to False.
+            multivariate (bool): If True, enables multivariate predictions.
+                Defaults to False. Note: multivariate predictions are only
+                supported for a select set of TimeGPT models. This variable
+                is different from the `threshold_method` parameter. The latter
+                controls the method used for anomaly detection (univariate vs
+                multivariate) whereas `multivariate` determines how the model
+                creates the predictions.
+            job_timeout_seconds (int, optional): Maximum seconds the server
+                allows this job to run before terminating it server-side.
+                This is separate from `poll_timeout` in `Job.wait()`, which
+                only controls how long the client polls locally. Capped by a
+                server-side per-task maximum; requesting a higher value
+                raises `ApiError` (422) when submitting. Defaults to the
+                server's default for this task type if not specified.
+
+        Returns:
+            Job: Handle to the submitted job. `job.wait()` returns a pandas
+                or polars DataFrame with anomalies flagged by TimeGPT.
+        """
+        extra_param_checker.validate_python(model_parameters)
+        _ensure_local_dataframe(
+            df,
+            method_name="submit_anomaly_detection_job",
+            sync_method_name="detect_anomalies_online()",
         )
-        out = ufp.assign_columns(out, "TimeGPT", resp["mean"])
-        out = ufp.assign_columns(out, "anomaly", resp["anomaly"])
-        out = ufp.assign_columns(out, "anomaly_score", resp["anomaly_score"])
-        if threshold_method == "multivariate":
-            out = ufp.assign_columns(
-                out, "accumulated_anomaly_score", resp["accumulated_anomaly_score"]
-            )
-        return _maybe_add_intervals(out, resp["intervals"])
+        payload, parse_result = self._prepare_online_anomaly_detection(
+            df=df,
+            h=h,
+            detection_size=detection_size,
+            threshold_method=threshold_method,
+            freq=freq,
+            id_col=id_col,
+            time_col=time_col,
+            target_col=target_col,
+            level=level,
+            clean_ex_first=clean_ex_first,
+            step_size=step_size,
+            finetune_steps=finetune_steps,
+            finetune_depth=finetune_depth,
+            finetune_loss=finetune_loss,
+            finetuned_model_id=finetuned_model_id,
+            hist_exog_list=hist_exog_list,
+            date_features=date_features,
+            date_features_to_one_hot=date_features_to_one_hot,
+            model=model,
+            model_parameters=model_parameters,
+            refit=refit,
+            multivariate=multivariate,
+        )
+        return self._submit_and_wrap_job(
+            "v2/anomaly_detection", payload, job_timeout_seconds, parse_result
+        )
 
     def _distributed_cross_validation(
         self,
@@ -6028,10 +6268,12 @@ def _detect_anomalies_online_wrapper(
     finetune_steps: _NonNegativeInt,
     finetune_depth: _FinetuneDepth,
     finetune_loss: _Loss,
+    finetuned_model_id: Optional[str],
     hist_exog_list: Optional[list[str]],
     date_features: Union[bool, list[str]],
     date_features_to_one_hot: Union[bool, list[str]],
     model: _Model,
+    model_parameters: _ExtraParamDataType,
     refit: bool,
     num_partitions: Optional[_PositiveInt],
     multivariate: bool,
@@ -6051,10 +6293,12 @@ def _detect_anomalies_online_wrapper(
         finetune_steps=finetune_steps,
         finetune_depth=finetune_depth,
         finetune_loss=finetune_loss,
+        finetuned_model_id=finetuned_model_id,
         hist_exog_list=hist_exog_list,
         date_features=date_features,
         date_features_to_one_hot=date_features_to_one_hot,
         model=model,
+        model_parameters=model_parameters,
         refit=refit,
         num_partitions=num_partitions,
         multivariate=multivariate,

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -324,6 +324,10 @@ _ASYNC_JOB_POLL_JITTER = 0.25
 # submission pressure; it is not a guarantee of the deployment's team job cap.
 _MAX_CONCURRENT_ASYNC_JOBS = 5
 
+# The server is mid-rename: the async route already uses the post-rename name
+_ANOMALY_DETECTION_ENDPOINT = "v2/anomaly_detection"
+_ONLINE_ANOMALY_DETECTION_ENDPOINT = "v2/online_anomaly_detection"
+
 
 def _wait_for_poll(seconds: float, cancellation_event: Optional[Event]) -> bool:
     """Wait for the next poll, returning whether cancellation was requested."""
@@ -2156,15 +2160,26 @@ class NixtlaClient:
         payload = _with_job_options(payload, job_timeout_seconds)
         with self._make_client(**self._client_kwargs) as client:
             job_id = self._submit_job(client, endpoint, payload)
+
+        def get_result(job_data: dict[str, Any], *_poll_settings: float) -> Any:
+            # A JSON result is inline in the status response, so there is nothing to wait
+            # for: the poll settings `Job` passes are accepted and ignored.
+            result = job_data.get("result")
+            if not isinstance(result, dict):
+                # Same guard as `_run_async_job`: a malformed success must not surface
+                # as a `TypeError` from inside `parse_result`.
+                raise AsyncJobError(
+                    job_id=job_id,
+                    status="succeeded",
+                    error="job succeeded but returned no result",
+                )
+            return parse_result(result)
+
         return Job(
             client=self,
             job_id=job_id,
             endpoint=endpoint,
-            # A JSON result is inline in the status response, so there is nothing to wait
-            # for: the poll settings `Job` passes are accepted and ignored.
-            get_result=lambda job_data, *_poll_settings: parse_result(
-                job_data["result"]
-            ),
+            get_result=get_result,
         )
 
     def _submit_binary_job(
@@ -4476,12 +4491,12 @@ class NixtlaClient:
         with self._make_client(**self._client_kwargs) as client:
             if num_partitions is None:
                 resp = self._make_request_with_retries(
-                    client, "v2/anomaly_detection", payload
+                    client, _ANOMALY_DETECTION_ENDPOINT, payload
                 )
             else:
                 payloads = _partition_series(payload, num_partitions, h=0)
                 resp = self._make_partitioned_requests(
-                    client, "v2/anomaly_detection", payloads
+                    client, _ANOMALY_DETECTION_ENDPOINT, payloads
                 )
 
         # assemble result
@@ -4573,7 +4588,7 @@ class NixtlaClient:
         )
         return fa.get_native_as_df(result_df)
 
-    def _prepare_online_anomaly_detection(
+    def _prepare_anomaly_detection(
         self,
         df: DFType,
         h: _PositiveInt,
@@ -4598,12 +4613,7 @@ class NixtlaClient:
         refit: bool,
         multivariate: bool,
     ) -> tuple[dict[str, Any], Callable[[dict[str, Any]], Any]]:
-        """Build the online anomaly detection payload and its result parser.
-
-        Shared by `detect_anomalies_online` and `submit_anomaly_detection_job` so the
-        two paths cannot drift: the payload is identical and `parse_result` assembles
-        the response the same way whether it arrived inline or from a finished job.
-        """
+        """Build the payload and result parser shared by the sync and submit paths."""
         self.__dict__.pop("weights_x", None)
         model = self._maybe_override_model(model)
         logger.info("Validating inputs...")
@@ -4634,6 +4644,11 @@ class NixtlaClient:
         if processed.sort_idxs is not None:
             targets = targets[processed.sort_idxs]
             times = times[processed.sort_idxs]
+        else:
+            # Own these: otherwise they are views into `df`, and `parse_result` can run
+            # long after submit returned, by which time `df` may have been mutated.
+            targets = targets.copy()
+            times = times.copy()
         X, hist_exog = _process_exog_features(processed.data, x_cols, hist_exog_list)
         sizes = np.diff(processed.indptr)
         if np.all(sizes <= 6 * detection_size):
@@ -4672,13 +4687,18 @@ class NixtlaClient:
         if model_parameters is not None:
             payload.update({"model_parameters": model_parameters})
 
+        # A `Job` holds `parse_result` until the caller drops it, so capturing
+        # `df`/`processed` would pin the whole input for that long.
+        df_cls = type(df)
+        uids = processed.uids
+
         def parse_result(resp: dict[str, Any]) -> Any:
             # assemble result
             idxs = np.array(resp["idxs"], dtype=np.int64)
             sizes = np.array(resp["sizes"], dtype=np.int64)
-            out = type(df)(
+            out = df_cls(
                 {
-                    id_col: ufp.repeat(processed.uids, sizes),
+                    id_col: ufp.repeat(uids, sizes),
                     time_col: times[idxs],
                     target_col: targets[idxs],
                 }
@@ -4690,7 +4710,8 @@ class NixtlaClient:
                 out = ufp.assign_columns(
                     out, "accumulated_anomaly_score", resp["accumulated_anomaly_score"]
                 )
-            return _maybe_add_intervals(out, resp["intervals"])
+            # Optional in the response schema; `_maybe_add_intervals` no-ops on None.
+            return _maybe_add_intervals(out, resp.get("intervals"))
 
         return payload, parse_result
 
@@ -4851,7 +4872,7 @@ class NixtlaClient:
                 "Either set threshold_method to univariate "
                 "or set num_partitions to None."
             )
-        payload, parse_result = self._prepare_online_anomaly_detection(
+        payload, parse_result = self._prepare_anomaly_detection(
             df=df,
             h=h,
             detection_size=detection_size,
@@ -4879,12 +4900,12 @@ class NixtlaClient:
         with self._make_client(**self._client_kwargs) as client:
             if num_partitions is None:
                 resp = self._make_request_with_retries(
-                    client, "v2/online_anomaly_detection", payload
+                    client, _ONLINE_ANOMALY_DETECTION_ENDPOINT, payload
                 )
             else:
                 payloads = _partition_series(payload, num_partitions, h=0)
                 resp = self._make_partitioned_requests(
-                    client, "v2/online_anomaly_detection", payloads
+                    client, _ONLINE_ANOMALY_DETECTION_ENDPOINT, payloads
                 )
         return parse_result(resp)
 
@@ -5024,7 +5045,7 @@ class NixtlaClient:
             method_name="submit_anomaly_detection_job",
             sync_method_name="detect_anomalies_online()",
         )
-        payload, parse_result = self._prepare_online_anomaly_detection(
+        payload, parse_result = self._prepare_anomaly_detection(
             df=df,
             h=h,
             detection_size=detection_size,
@@ -5049,7 +5070,7 @@ class NixtlaClient:
             multivariate=multivariate,
         )
         return self._submit_and_wrap_job(
-            "v2/anomaly_detection", payload, job_timeout_seconds, parse_result
+            _ANOMALY_DETECTION_ENDPOINT, payload, job_timeout_seconds, parse_result
         )
 
     def _distributed_cross_validation(

--- a/nixtla_tests/nixtla_client/test_async_jobs.py
+++ b/nixtla_tests/nixtla_client/test_async_jobs.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import httpx
+import numpy as np
 import orjson
 import pandas as pd
 import pytest
@@ -323,7 +324,8 @@ def test_make_request_still_rejects_other_status_codes():
 
 
 # ---------------------------------------------------------------------------
-# submit_finetune_job / submit_forecast_job / submit_cross_validation_job
+# submit_finetune_job / submit_forecast_job / submit_cross_validation_job /
+# submit_anomaly_detection_job
 # ---------------------------------------------------------------------------
 
 # (method_name, endpoint, call_kwargs factory, _get_model_params return value or
@@ -349,6 +351,15 @@ SUBMIT_JOB_CASES = [
         lambda: {"df": _small_df(), "h": 5},
         (10_000, 12),
         id="cross_validation",
+    ),
+    # The async route uses the post-rename endpoint name, so it deliberately
+    # differs from the `v2/online_anomaly_detection` path the sync method posts to.
+    pytest.param(
+        "submit_anomaly_detection_job",
+        "v2/anomaly_detection",
+        lambda: {"df": _small_df(), "h": 5, "detection_size": 5},
+        None,
+        id="anomaly_detection",
     ),
 ]
 
@@ -413,6 +424,27 @@ def _cross_validation_poll_response():
     }
 
 
+def _anomaly_detection_poll_response():
+    n, detection_size = 20, 5
+    return {
+        "status": "succeeded",
+        "result": {
+            "idxs": list(range(n - detection_size, n)),
+            "sizes": [detection_size],
+            "mean": list(range(detection_size)),
+            "anomaly": [False] * detection_size,
+            "anomaly_score": [0.0] * detection_size,
+            "intervals": None,
+        },
+    }
+
+
+def _anomaly_detection_multivariate_poll_response():
+    resp = _anomaly_detection_poll_response()
+    resp["result"]["accumulated_anomaly_score"] = [0.0] * 5
+    return resp
+
+
 def _check_finetune_result(result):
     assert result == "abc123"
 
@@ -420,6 +452,19 @@ def _check_finetune_result(result):
 def _check_point_forecast_df(result):
     assert len(result) == 5
     assert result["TimeGPT"].tolist() == list(range(5))
+
+
+def _check_anomaly_df(result):
+    _check_point_forecast_df(result)
+    assert result["anomaly"].tolist() == [False] * 5
+    assert result["anomaly_score"].tolist() == [0.0] * 5
+    # univariate thresholding must not add the multivariate-only column
+    assert "accumulated_anomaly_score" not in result.columns
+
+
+def _check_multivariate_anomaly_df(result):
+    _check_point_forecast_df(result)
+    assert result["accumulated_anomaly_score"].tolist() == [0.0] * 5
 
 
 WAIT_JOB_CASES = [
@@ -447,6 +492,27 @@ WAIT_JOB_CASES = [
         _check_point_forecast_df,
         id="cross_validation",
     ),
+    pytest.param(
+        "submit_anomaly_detection_job",
+        lambda: {"df": _small_df(n=20), "h": 5, "detection_size": 5},
+        None,
+        _anomaly_detection_poll_response,
+        _check_anomaly_df,
+        id="anomaly_detection",
+    ),
+    pytest.param(
+        "submit_anomaly_detection_job",
+        lambda: {
+            "df": _small_df(n=20),
+            "h": 5,
+            "detection_size": 5,
+            "threshold_method": "multivariate",
+        },
+        None,
+        _anomaly_detection_multivariate_poll_response,
+        _check_multivariate_anomaly_df,
+        id="anomaly_detection_multivariate",
+    ),
 ]
 
 
@@ -473,6 +539,94 @@ def test_submit_job_wait_returns_result(
     check_result(result)
     assert job.status == "succeeded"
     assert job.result is result
+
+
+def _normalize_payload(payload):
+    """Make a payload comparable: numpy arrays -> lists, recursively."""
+    if isinstance(payload, dict):
+        return {k: _normalize_payload(v) for k, v in payload.items()}
+    if isinstance(payload, np.ndarray):
+        return payload.tolist()
+    if isinstance(payload, (list, tuple)):
+        return [_normalize_payload(v) for v in payload]
+    return payload
+
+
+def test_submit_anomaly_detection_job_payload_matches_sync(monkeypatch):
+    """`submit_anomaly_detection_job` must send what `detect_anomalies_online` sends.
+
+    Both build their request through `_prepare_online_anomaly_detection`, so this
+    pins that the two paths cannot drift apart. Only the endpoint differs: the
+    async route already uses the post-rename `v2/anomaly_detection` name.
+    """
+    call_kwargs = dict(
+        df=_small_df(n=20),
+        h=5,
+        detection_size=5,
+        freq="D",
+        finetuned_model_id="ft-abc",
+        model_parameters={"foo": "bar"},
+    )
+    captured = {}
+
+    def fake_submit_job(self, client, endpoint, payload, multithreaded_compress=True, **kwargs):
+        captured["async"] = (endpoint, _normalize_payload(payload))
+        return "job-1"
+
+    def fake_make_request_with_retries(self, client, endpoint, payload, **kwargs):
+        captured["sync"] = (endpoint, _normalize_payload(payload))
+        return _anomaly_detection_poll_response()["result"]
+
+    monkeypatch.setattr(NixtlaClient, "_submit_job", fake_submit_job)
+    monkeypatch.setattr(
+        NixtlaClient, "_make_request_with_retries", fake_make_request_with_retries
+    )
+    _stub_job_status(monkeypatch, "pending")
+    client = _client()
+
+    client.submit_anomaly_detection_job(**call_kwargs)
+    client.detect_anomalies_online(**call_kwargs)
+
+    async_endpoint, async_payload = captured["async"]
+    sync_endpoint, sync_payload = captured["sync"]
+
+    assert async_endpoint == "v2/anomaly_detection"
+    assert sync_endpoint == "v2/online_anomaly_detection"
+    # both newly exposed parameters actually reach the wire
+    assert async_payload["finetuned_model_id"] == "ft-abc"
+    assert async_payload["model_parameters"] == {"foo": "bar"}
+    assert async_payload == sync_payload
+
+
+def test_submit_anomaly_detection_job_omits_model_parameters_when_unset(monkeypatch):
+    # `model_parameters` is only sent when set, matching cross_validation.
+    captured = {}
+
+    def fake_submit_job(self, client, endpoint, payload, multithreaded_compress=True, **kwargs):
+        captured["payload"] = payload
+        return "job-1"
+
+    monkeypatch.setattr(NixtlaClient, "_submit_job", fake_submit_job)
+    _stub_job_status(monkeypatch, "pending")
+    client = _client()
+
+    client.submit_anomaly_detection_job(df=_small_df(n=20), h=5, detection_size=5, freq="D")
+
+    assert "model_parameters" not in captured["payload"]
+    assert captured["payload"]["finetuned_model_id"] is None
+
+
+def test_submit_anomaly_detection_job_rejects_bad_model_parameters():
+    # Validated up front by `extra_param_checker`, before any request is built.
+    client = _client()
+    with pytest.raises(TypeError, match="Invalid value type"):
+        client.submit_anomaly_detection_job(
+            df=_small_df(n=20),
+            h=5,
+            detection_size=5,
+            freq="D",
+            model_parameters={"horizon": pd.DataFrame()},
+        )
 
 
 def test_job_cancel_calls_cancel_job(monkeypatch):
@@ -1139,14 +1293,23 @@ def test_cross_validation_num_partitions_with_async_job(monkeypatch):
     assert len(out) == h * 2
 
 
-@pytest.mark.parametrize("method_name", ["submit_forecast_job", "submit_cross_validation_job"])
-def test_submit_job_with_unrecognized_df_type_still_raises(method_name):
-    # submit_forecast_job/submit_cross_validation_job don't support distributed
-    # (dask/spark/ray) dataframes in this version — an arbitrary non-pandas/polars
-    # object should raise a clear ValueError rather than doing something undefined.
+# `extra_kwargs` carries each method's other required arguments, so the call reaches
+# the dataframe-type guard instead of failing earlier on a missing argument.
+@pytest.mark.parametrize(
+    "method_name, extra_kwargs",
+    [
+        ("submit_forecast_job", {}),
+        ("submit_cross_validation_job", {}),
+        ("submit_anomaly_detection_job", {"detection_size": 5}),
+    ],
+)
+def test_submit_job_with_unrecognized_df_type_still_raises(method_name, extra_kwargs):
+    # These methods don't support distributed (dask/spark/ray) dataframes in this
+    # version — an arbitrary non-pandas/polars object should raise a clear
+    # ValueError rather than doing something undefined.
     client = _client()
     with pytest.raises(ValueError, match=f"{method_name} only supports"):
-        getattr(client, method_name)(df=[1, 2, 3], h=5)
+        getattr(client, method_name)(df=[1, 2, 3], h=5, **extra_kwargs)
 
 
 @pytest.mark.parametrize(

--- a/nixtla_tests/nixtla_client/test_async_jobs.py
+++ b/nixtla_tests/nixtla_client/test_async_jobs.py
@@ -352,8 +352,7 @@ SUBMIT_JOB_CASES = [
         (10_000, 12),
         id="cross_validation",
     ),
-    # The async route uses the post-rename endpoint name, so it deliberately
-    # differs from the `v2/online_anomaly_detection` path the sync method posts to.
+    # Deliberately not the sync method's endpoint; literal so it pins the wire value.
     pytest.param(
         "submit_anomaly_detection_job",
         "v2/anomaly_detection",
@@ -434,6 +433,9 @@ def _anomaly_detection_poll_response():
             "mean": list(range(detection_size)),
             "anomaly": [False] * detection_size,
             "anomaly_score": [0.0] * detection_size,
+            # Present on purpose in the univariate case, so `_check_anomaly_df`'s
+            # absence assertion fails instead of raising KeyError.
+            "accumulated_anomaly_score": [0.0] * detection_size,
             "intervals": None,
         },
     }
@@ -449,13 +451,13 @@ def _check_finetune_result(result):
     assert result == "abc123"
 
 
-def _check_point_forecast_df(result):
+def _check_mean_and_len(result):
     assert len(result) == 5
     assert result["TimeGPT"].tolist() == list(range(5))
 
 
 def _check_anomaly_df(result):
-    _check_point_forecast_df(result)
+    _check_mean_and_len(result)
     assert result["anomaly"].tolist() == [False] * 5
     assert result["anomaly_score"].tolist() == [0.0] * 5
     # univariate thresholding must not add the multivariate-only column
@@ -463,7 +465,9 @@ def _check_anomaly_df(result):
 
 
 def _check_multivariate_anomaly_df(result):
-    _check_point_forecast_df(result)
+    _check_mean_and_len(result)
+    assert result["anomaly"].tolist() == [False] * 5
+    assert result["anomaly_score"].tolist() == [0.0] * 5
     assert result["accumulated_anomaly_score"].tolist() == [0.0] * 5
 
 
@@ -481,7 +485,7 @@ WAIT_JOB_CASES = [
         lambda: {"df": _small_df(), "h": 5},
         (100, 12),
         _forecast_poll_response,
-        _check_point_forecast_df,
+        _check_mean_and_len,
         id="forecast",
     ),
     pytest.param(
@@ -489,7 +493,7 @@ WAIT_JOB_CASES = [
         lambda: {"df": _small_df(n=20), "h": 5},
         (10_000, 12),
         _cross_validation_poll_response,
-        _check_point_forecast_df,
+        _check_mean_and_len,
         id="cross_validation",
     ),
     pytest.param(
@@ -541,6 +545,11 @@ def test_submit_job_wait_returns_result(
     assert job.result is result
 
 
+# ---------------------------------------------------------------------------
+# submit_anomaly_detection_job specifics
+# ---------------------------------------------------------------------------
+
+
 def _normalize_payload(payload):
     """Make a payload comparable: numpy arrays -> lists, recursively."""
     if isinstance(payload, dict):
@@ -581,7 +590,6 @@ def test_submit_anomaly_detection_job_payload_matches_sync(monkeypatch):
     monkeypatch.setattr(
         NixtlaClient, "_make_request_with_retries", fake_make_request_with_retries
     )
-    _stub_job_status(monkeypatch, "pending")
     client = _client()
 
     client.submit_anomaly_detection_job(**call_kwargs)
@@ -1293,23 +1301,22 @@ def test_cross_validation_num_partitions_with_async_job(monkeypatch):
     assert len(out) == h * 2
 
 
-# `extra_kwargs` carries each method's other required arguments, so the call reaches
-# the dataframe-type guard instead of failing earlier on a missing argument.
+# `call_kwargs` supplies each method's required args so the call reaches the
+# dataframe-type guard. `submit_finetune_job` has no such guard, so it is absent.
 @pytest.mark.parametrize(
-    "method_name, extra_kwargs",
+    "method_name, call_kwargs",
     [
-        ("submit_forecast_job", {}),
-        ("submit_cross_validation_job", {}),
-        ("submit_anomaly_detection_job", {"detection_size": 5}),
+        ("submit_forecast_job", {"h": 5}),
+        ("submit_cross_validation_job", {"h": 5}),
+        ("submit_anomaly_detection_job", {"h": 5, "detection_size": 5}),
     ],
 )
-def test_submit_job_with_unrecognized_df_type_still_raises(method_name, extra_kwargs):
-    # These methods don't support distributed (dask/spark/ray) dataframes in this
-    # version — an arbitrary non-pandas/polars object should raise a clear
-    # ValueError rather than doing something undefined.
+def test_submit_job_with_unrecognized_df_type_still_raises(method_name, call_kwargs):
+    # No distributed (dask/spark/ray) support in this version, so a non-pandas/polars
+    # object must raise a clear ValueError.
     client = _client()
     with pytest.raises(ValueError, match=f"{method_name} only supports"):
-        getattr(client, method_name)(df=[1, 2, 3], h=5, **extra_kwargs)
+        getattr(client, method_name)(df=[1, 2, 3], **call_kwargs)
 
 
 @pytest.mark.parametrize(

--- a/nixtla_tests/nixtla_client/test_distributed_async_wrappers.py
+++ b/nixtla_tests/nixtla_client/test_distributed_async_wrappers.py
@@ -2,7 +2,11 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 
-from nixtla.nixtla_client import _cross_validation_wrapper, _forecast_wrapper
+from nixtla.nixtla_client import (
+    _cross_validation_wrapper,
+    _detect_anomalies_online_wrapper,
+    _forecast_wrapper,
+)
 
 
 def _small_df(n=20):
@@ -137,3 +141,44 @@ def test_cross_validation_wrapper_forwards_async_kwargs():
     assert kwargs["_poll_interval"] == 7
     assert kwargs["_poll_timeout"] == 42
     assert kwargs["_job_timeout_seconds"] == 300
+
+
+def test_detect_anomalies_online_wrapper_forwards_all_params():
+    # No async-job path here; this pins that the params Fugue passes through
+    # `_distributed_detect_anomalies_online` reach `detect_anomalies_online`.
+    mock_client = MagicMock()
+
+    _detect_anomalies_online_wrapper(
+        df=_small_df(),
+        client=mock_client,
+        h=5,
+        detection_size=5,
+        threshold_method="univariate",
+        freq="D",
+        id_col="unique_id",
+        time_col="ds",
+        target_col="y",
+        level=99,
+        clean_ex_first=True,
+        step_size=None,
+        finetune_steps=0,
+        finetune_depth=1,
+        finetune_loss="default",
+        finetuned_model_id="ft-abc",
+        hist_exog_list=None,
+        date_features=False,
+        date_features_to_one_hot=False,
+        model="timegpt-2.1",
+        model_parameters={"foo": "bar"},
+        refit=False,
+        num_partitions=None,
+        multivariate=False,
+    )
+
+    mock_client.detect_anomalies_online.assert_called_once()
+    kwargs = mock_client.detect_anomalies_online.call_args.kwargs
+    assert kwargs["finetuned_model_id"] == "ft-abc"
+    assert kwargs["model_parameters"] == {"foo": "bar"}
+    assert kwargs["detection_size"] == 5
+    assert kwargs["threshold_method"] == "univariate"
+    assert kwargs["level"] == 99


### PR DESCRIPTION
## What

Adds `NixtlaClient.submit_anomaly_detection_job`, the asynchronous counterpart to `detect_anomalies_online`: it submits a server-side job and returns a `Job` handle instead of blocking, so `job.wait()` yields the same DataFrame the sync method would. `num_partitions` is not supported, matching `submit_forecast_job`.

Payload construction and response assembly were extracted out of `detect_anomalies_online` into a shared `_prepare_anomaly_detection()` returning `(payload, parse_result)` — the same shape as `_prepare_forecast` and `_prepare_cross_validation` — so the sync and async paths cannot drift. The sync method is otherwise unchanged.

## Note on the endpoint

The async route is `v2/anomaly_detection/async` while the sync method still posts to `v2/online_anomaly_detection`. This is deliberate: the server already adopted the post-rename name for its async routes. Worth flagging for review, because `openapi.json` documents no async routes at all and so cannot be used to check this — it was verified against the live API instead. Both bases are now named constants, so the planned rename of `detect_anomalies_online` → `anomaly_detection` stays contained.

## Also included

`detect_anomalies_online` now accepts `finetuned_model_id` and `model_parameters`, which the API already supported but the client never exposed; both are threaded through the distributed path. They sit mid-signature to match `forecast`/`cross_validation` ordering, so **callers passing arguments positionally past `finetune_loss` must switch to keywords**. Its request body now always carries `finetuned_model_id` (previously omitted when unset).

## Testing

Offline coverage extends the existing `SUBMIT_JOB_CASES` / `WAIT_JOB_CASES` tables (including the multivariate branch) and adds a payload-parity test pinning the two paths together. Verified end-to-end against the live API: `job.wait()` output is `assert_frame_equal`-identical to `detect_anomalies_online` for both univariate and multivariate thresholds, and `job.cancel()` works. `ruff` and `mypy` (v1.10.1, the pinned pre-commit hook) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
