### PR TITLE
[FEAT] Add `list_models` to list the models available to an API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- New `list_models()` returns the sorted model names your API key may use, each usable as the `model` argument of `forecast`, `cross_validation` and the other forecasting methods. It needs the `GET /v2/models` route, which is not deployed yet; until it ships the call raises `ApiError` with status 404.
 - New `submit_anomaly_detection_job` submits online anomaly detection as a server-side job and returns a `Job` handle, the asynchronous counterpart to `detect_anomalies_online`. `num_partitions` is not supported; use `detect_anomalies_online` for distributed dataframes.
 - `detect_anomalies_online` accepts `finetuned_model_id` and `model_parameters`, which the API already supported but the client did not expose. Both are inserted mid-signature to match the parameter order used by `forecast` and `cross_validation`, so callers passing arguments **positionally** past `finetune_loss` must switch to keywords; its request body now also always carries `finetuned_model_id` (previously omitted when unset).
 - Async job results are validated before parsing: a job that reports success with a missing or non-object result now raises `AsyncJobError` instead of a `TypeError`, for every `submit_*_job` method.

--- a/nixtla/nixtla_client.py
+++ b/nixtla/nixtla_client.py
@@ -2576,6 +2576,19 @@ class NixtlaClient:
         with self._make_client(**self._client_kwargs) as client:
             return self._get_request(client, "/usage")
 
+    def list_models(self) -> list[str]:
+        """List the models available to your API key.
+
+        Returns:
+            list of str: Model names, sorted. Each can be passed as the `model`
+                argument of `forecast`, `cross_validation`, `detect_anomalies`
+                and the other forecasting methods; a model absent from this
+                list is one those methods would reject.
+        """
+        with self._make_client(**self._client_kwargs) as client:
+            resp_body = self._retry_strategy(self._get_request)(client, "/v2/models")
+        return sorted(m["name"] for m in resp_body["models"])
+
     def _prepare_finetune_payload(
         self,
         df: DataFrame,

--- a/nixtla_tests/nixtla_client/test_client.py
+++ b/nixtla_tests/nixtla_client/test_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from unittest.mock import MagicMock
@@ -245,3 +246,26 @@ def test_client_version_header_not_registered_without_metadata(monkeypatch):
     monkeypatch.setattr("nixtla.nixtla_client._resolve_nixtla_client_version", lambda: None)
     client = NixtlaClient(api_key="dummy")
     assert "nixtla-client-version" not in client._client_kwargs["headers"]
+
+
+def _make_json_response(status_code: int, body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = json.dumps(body).encode()
+    return resp
+
+
+def test_list_models_flattens_and_sorts_names():
+    """The endpoint nests names in objects so fields can be added later; the
+    client flattens them and sorts, independently of the server's order."""
+    client = NixtlaClient(api_key="dummy")
+    mock_http_client = MagicMock()
+    mock_http_client.get.return_value = _make_json_response(
+        200, {"models": [{"name": "timegpt-2"}, {"name": "timegpt-1"}]}
+    )
+    # route `with self._make_client(...) as client:` to the mock
+    client._make_client = MagicMock()
+    client._make_client.return_value.__enter__.return_value = mock_http_client
+
+    assert client.list_models() == ["timegpt-1", "timegpt-2"]
+    assert mock_http_client.get.call_args.args == ("/v2/models",)

--- a/timegpt-docs/reference/sdk_reference.mdx
+++ b/timegpt-docs/reference/sdk_reference.mdx
@@ -351,6 +351,24 @@ target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 href="https://github.com/Nixtla/nixtla/blob/main/nixtla/nixtla_client.py#LNone"
 target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
 
+## NixtlaClient.list_models
+
+> ``` text
+>  NixtlaClient.list_models ()
+> ```
+
+*List the models available to your API key.*
+
+|             | **Type**  | **Details**                                                                                                                                                                          |
+|-------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Returns** | **list**  | **Model names, sorted. Each can be passed as the `model` argument of `forecast`, `cross_validation`, `detect_anomalies` and the other forecasting methods; a model absent from this list is one those methods would reject.** |
+
+------------------------------------------------------------------------
+
+<a
+href="https://github.com/Nixtla/nixtla/blob/main/nixtla/nixtla_client.py#LNone"
+target="_blank" style={{ float: "right", fontSize: "smaller" }}>source</a>
+
 ## NixtlaClient.finetune
 
 > ``` text


### PR DESCRIPTION
## What

Adds `NixtlaClient.list_models()`, returning the sorted model names the API key may use. Each name is valid as the `model` argument of `forecast`, `cross_validation`, `detect_anomalies` and the other forecasting methods.

```python
client.list_models()
# ['timegpt-1', 'timegpt-1-long-horizon', 'timegpt-2']
```

The endpoint nests each name in an object (`{"models": [{"name": ...}]}`) so it can gain fields later without breaking clients; the SDK flattens that and sorts client-side, making the ordering the SDK's contract rather than the server's.
